### PR TITLE
Fix gradient update size check and add failing test

### DIFF
--- a/spec/cnn_spec.cr
+++ b/spec/cnn_spec.cr
@@ -248,4 +248,14 @@ describe SHAInet::CNN do
   #   puts "We managed #{correct_answers} out of #{test_data.data_pairs.size} total"
   #   puts "Cnn output: #{cnn.output}"
   # end
+
+  it "raises NeuralNetRunError when gradients array size mismatches" do
+    cnn = SHAInet::CNN.new
+    cnn.add_input([1, 1, 1])
+    cnn.add_fconnect(2)
+
+    expect_raises(SHAInet::NeuralNetRunError) do
+      cnn.update_output_gradients([0.1])
+    end
+  end
 end

--- a/src/shainet/cnn/cnn.cr
+++ b/src/shainet/cnn/cnn.cr
@@ -315,8 +315,8 @@ module SHAInet
     def update_output_gradients(cost_function_derivatives : Array(Float64))
       output_neurons = @layers.last.as(FullyConnectedLayer | SoftmaxLayer).all_neurons
 
-      unless new_gradients.size == output_neurons.size
-        raise NeuralNetRunError.new("New gradients array must be the same size as the output layer.")
+      unless cost_function_derivatives.size == output_neurons.size
+        raise NeuralNetRunError.new("Cost function derivatives array must be the same size as the output layer.")
       end
 
       output_neurons.each_with_index do |neuron, i|


### PR DESCRIPTION
## Summary
- ensure `update_output_gradients` checks `cost_function_derivatives` size
- raise a meaningful error on mismatch
- add a regression spec for `update_output_gradients`

## Testing
- `crystal spec --fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68581608a5f88331bf1546fee92a9db0