### PR TITLE
Fix normalization for constant columns

### DIFF
--- a/spec/data_spec.cr
+++ b/spec/data_spec.cr
@@ -78,4 +78,27 @@ describe SHAInet::Data do
     data.denormalize_outputs([0.5]).should eq([2.0])
     data.denormalize_outputs([1.0]).should eq([3.0])
   end
+
+  puts "############################################################"
+  it "should handle constant input columns" do
+    puts "\n"
+    inputs = [
+      [1.0, 5.0],
+      [2.0, 5.0],
+      [3.0, 5.0],
+    ]
+    outputs = [
+      [1.0],
+      [2.0],
+      [3.0],
+    ]
+
+    data = SHAInet::Data.new(inputs, outputs)
+    data.normalize_min_max
+    data.normalized_inputs.should eq([
+      [0.0, 1.0],
+      [0.5, 1.0],
+      [1.0, 1.0],
+    ])
+  end
 end

--- a/src/shainet/data/data.cr
+++ b/src/shainet/data/data.cr
@@ -115,6 +115,7 @@ module SHAInet
 
     def normalize(x, xmin, xmax)
       range = xmax - xmin
+      return @ymax.to_f64 if range == 0
       adj_x = x.to_f64 - (xmin + @ymin)
       norm = (@yrange / range)
       value = adj_x * norm
@@ -132,6 +133,7 @@ module SHAInet
 
     def denormalize(x, xmin, xmax)
       range = xmax - xmin
+      return xmin.to_f64 if range == 0
       denorm = x.to_f64 * (range / @yrange)
       adj_x = @ymin + xmin
       value = denorm + adj_x


### PR DESCRIPTION
## Summary
- avoid division by zero in `normalize` and `denormalize`
- cover constant column normalization in spec

## Testing
- `crystal spec spec/data_spec.cr`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_6858161898048331a94bdeb34d74848f