### PR TITLE
Add RNN/LSTM sequence learning tests

### DIFF
--- a/spec/lstm_spec.cr
+++ b/spec/lstm_spec.cr
@@ -16,4 +16,19 @@ describe SHAInet::LSTMLayer do
     outputs = net.run(seq)
     outputs.size.should eq(3)
   end
+
+  it "learns to predict the last value of a sequence" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:lstm, 1)
+    net.add_layer(:output, 1, :memory, SHAInet.none)
+    net.fully_connect
+
+    seq = [[1.0], [2.0], [3.0]]
+    expected = 3.0
+    net.train([[seq, [expected]]], training_type: :sgdm,
+      epochs: 500, mini_batch_size: 1, log_each: 500)
+    result = net.run(seq).last.first
+    result.should be_close(expected, 0.1)
+  end
 end

--- a/spec/rnn_spec.cr
+++ b/spec/rnn_spec.cr
@@ -16,5 +16,20 @@ describe SHAInet::RecurrentLayer do
     outputs = net.run(seq)
     outputs.size.should eq(3)
   end
+
+  it "learns to predict the last value of a sequence" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:recurrent, 1, :memory, SHAInet.sigmoid)
+    net.add_layer(:output, 1, :memory, SHAInet.none)
+    net.fully_connect
+
+    seq = [[1.0], [2.0], [3.0]]
+    expected = 3.0
+    net.train([[seq, [expected]]], training_type: :sgdm,
+      epochs: 500, mini_batch_size: 1, log_each: 500)
+    result = net.run(seq).last.first
+    result.should be_close(expected, 0.1)
+  end
 end
 


### PR DESCRIPTION
## Summary
- extend rnn spec with training on a simple sequence prediction task
- add similar lstm spec verifying the layer learns the sequence

## Testing
- `crystal spec spec/rnn_spec.cr spec/lstm_spec.cr --order random`
- `crystal spec --order random`


------
https://chatgpt.com/codex/tasks/task_e_68594611f680833184886c79b921c5e7