### PR TITLE
Update embedding layer training

### DIFF
--- a/spec/embedding_layer_spec.cr
+++ b/spec/embedding_layer_spec.cr
@@ -8,4 +8,22 @@ describe SHAInet::EmbeddingLayer do
     first.should eq(second)
     layer.neurons.map(&.activation).should eq(first)
   end
+
+  it "updates embeddings during training" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:embedding, 2, :memory, SHAInet.none)
+    net.add_layer(:output, 1, :memory, SHAInet.none)
+    net.fully_connect
+
+    layer = net.hidden_layers.first.as(SHAInet::EmbeddingLayer)
+    before = layer.embed(1).dup
+
+    training = [ [[1], [0.5]] ]
+    net.learning_rate = 0.1
+    net.train(data: training, training_type: :sgdm, epochs: 1, mini_batch_size: 1, log_each: 1)
+
+    after = layer.embeddings[1]
+    after.should_not eq(before)
+  end
 end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -292,6 +292,13 @@ module SHAInet
               l.neurons.each { |neuron| neuron.hidden_error_prop }
             end
 
+            # Collect gradients for embedding layers before summing
+            @hidden_layers.each do |l|
+              if l.is_a?(EmbeddingLayer)
+                l.as(EmbeddingLayer).accumulate_gradient
+              end
+            end
+
             # Sum all gradients from each data point for the batch update
             @all_synapses.each_with_index { |synapse, i| @w_gradient[i] += (synapse.source_neuron.activation)*(synapse.dest_neuron.gradient) }
             @all_neurons.each_with_index { |neuron, i| @b_gradient[i] += neuron.gradient }
@@ -471,6 +478,13 @@ module SHAInet
 
           neuron.m_prev = neuron.m_current
           neuron.v_prev = neuron.v_current
+        end
+      end
+
+      # Update embeddings after using neuron gradients
+      @hidden_layers.each do |layer|
+        if layer.is_a?(EmbeddingLayer)
+          layer.as(EmbeddingLayer).apply_gradients(@learning_rate)
         end
       end
     end

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -101,6 +101,8 @@ module SHAInet
       when "lstm"
         @hidden_layers << layer
         @lstm_layers << layer.as(LSTMLayer)
+      when "embedding"
+        @hidden_layers << layer
       when "output"
         if @output_layers.empty?
           @output_layers << layer

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -2,10 +2,14 @@ module SHAInet
   # Simple embedding lookup table. Maps integer token IDs to vectors of floats.
   class EmbeddingLayer < Layer
     property embeddings : Hash(Int32, Array(Float64))
+    property gradients : Hash(Int32, Array(Float64))
+    getter current_ids : Array(Int32)
 
     def initialize(l_size : Int32, activation_function : ActivationFunction = SHAInet.none)
       super("memory", l_size, activation_function)
       @embeddings = Hash(Int32, Array(Float64)).new
+      @gradients = Hash(Int32, Array(Float64)).new
+      @current_ids = [] of Int32
     end
 
     # Retrieve embedding vector for the given token id. If the token id does not
@@ -21,7 +25,30 @@ module SHAInet
       vec.each_with_index do |v, i|
         @neurons[i].activation = v
       end
+      @current_ids << id
       vec
+    end
+
+    # Accumulate gradient for the last embedded ids
+    def accumulate_gradient
+      until @current_ids.empty?
+        id = @current_ids.shift
+        grad = @gradients[id] ||= Array(Float64).new(@l_size, 0.0)
+        @neurons.each_with_index do |n, i|
+          grad[i] += n.gradient
+        end
+      end
+    end
+
+    # Update embeddings using stored gradients and clear them
+    def apply_gradients(lr : Float64)
+      @gradients.each do |id, grad|
+        emb = lookup(id)
+        grad.each_with_index do |g, i|
+          emb[i] -= lr*g
+          grad[i] = 0.0
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- store gradients per token id for `EmbeddingLayer`
- accumulate and apply embedding gradients during training
- allow `:embedding` as a layer type
- add regression spec to ensure embeddings are updated

## Testing
- `crystal spec -v`

------
https://chatgpt.com/codex/tasks/task_e_68596054c550833193a05eed4dfe75ac