### PR TITLE
Add BPE tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,15 @@ net.fully_connect
 sequence = ids.map { |id| [id.to_f64] }
 output = net.run(sequence).last
 ```
+
+Example of a Byte-Pair Encoding tokenizer:
+
+```crystal
+tokenizer = SHAInet::BPETokenizer.new
+tokenizer.train("hello world hello world", 30)
+ids = tokenizer.encode("hello world")
+text = tokenizer.decode(ids)
+```
   
 ### Possible Future Features
   - [x] RNN (recurant neural network)

--- a/spec/bpe_tokenizer_spec.cr
+++ b/spec/bpe_tokenizer_spec.cr
@@ -1,0 +1,10 @@
+require "./spec_helper"
+
+describe SHAInet::BPETokenizer do
+  it "encodes and decodes text after training" do
+    tokenizer = SHAInet::BPETokenizer.new
+    tokenizer.train("hello world hello world", 30)
+    encoded = tokenizer.encode("hello world")
+    tokenizer.decode(encoded).should eq("hello world")
+  end
+end

--- a/src/shainet/text/bpe_tokenizer.cr
+++ b/src/shainet/text/bpe_tokenizer.cr
@@ -1,0 +1,103 @@
+module SHAInet
+  # Simple byte-pair encoding tokenizer. It can train a vocabulary
+  # from text and encode/decode using the learned merges.
+  class BPETokenizer
+    getter vocab : Hash(String, Int32)
+    getter inv_vocab : Array(String)
+    getter merges : Array(Tuple(String, String))
+
+    def initialize
+      @vocab = Hash(String, Int32).new
+      @inv_vocab = [] of String
+      @merges = [] of Tuple(String, String)
+    end
+
+    # Train the tokenizer vocabulary from the given text using the
+    # byte-pair encoding algorithm. `vocab_size` determines how many
+    # unique tokens will be created at most.
+    def train(text : String, vocab_size : Int32)
+      corpus = text.split(/\s+/).map { |w| w.chars.map(&.to_s) + ["</w>"] }
+      corpus.each do |tokens|
+        tokens.each { |t| add_token(t) }
+      end
+
+      while @vocab.size < vocab_size
+        pair_counts = Hash(Tuple(String, String), Int32).new(0)
+        corpus.each do |tokens|
+          (0...(tokens.size - 1)).each do |i|
+            pair = {tokens[i], tokens[i + 1]}
+            pair_counts[pair] += 1
+          end
+        end
+        break if pair_counts.empty?
+        best_pair, _ = pair_counts.max_by { |_, count| count }
+        new_token = best_pair[0] + best_pair[1]
+        corpus.each do |tokens|
+          i = 0
+          while i < tokens.size - 1
+            if tokens[i] == best_pair[0] && tokens[i + 1] == best_pair[1]
+              tokens[i] = new_token
+              tokens.delete_at(i + 1)
+            else
+              i += 1
+            end
+          end
+        end
+        @merges << best_pair
+        add_token(new_token)
+      end
+    end
+
+    # Encode a string into token IDs. Unknown tokens are added to the
+    # vocabulary.
+    def encode(text : String) : Array(Int32)
+      ids = [] of Int32
+      text.split(/\s+/).each do |word|
+        tokens = word.chars.map(&.to_s) + ["</w>"]
+        @merges.each { |pair| merge_tokens!(tokens, pair) }
+        tokens.each { |t| ids << add_token(t) }
+      end
+      ids
+    end
+
+    # Decode an array of token IDs back into a string.
+    def decode(ids : Array(Int32)) : String
+      words = [] of String
+      current = ""
+      ids.each do |id|
+        token = @inv_vocab[id]? || ""
+        if token.ends_with?("</w>")
+          current += token.chomp("</w>")
+          words << current
+          current = ""
+        else
+          current += token
+        end
+      end
+      words.join(" ")
+    end
+
+    private def merge_tokens!(tokens : Array(String), pair : Tuple(String, String))
+      i = 0
+      while i < tokens.size - 1
+        if tokens[i] == pair[0] && tokens[i + 1] == pair[1]
+          tokens[i] = pair[0] + pair[1]
+          tokens.delete_at(i + 1)
+        else
+          i += 1
+        end
+      end
+    end
+
+    private def add_token(token : String) : Int32
+      if id = @vocab[token]?
+        id
+      else
+        new_id = @vocab.size
+        @vocab[token] = new_id
+        @inv_vocab << token
+        new_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement simple byte-pair encoding (BPE) tokenizer
- test BPE tokenizer training and encode/decode
- document BPE tokenizer usage

## Testing
- `crystal spec --no-color`

------
https://chatgpt.com/codex/tasks/task_e_68596128ed008331bf74855660cbf5c9