### PR TITLE
Add SimpleMatrix for basic matrix ops

### DIFF
--- a/spec/simple_matrix_spec.cr
+++ b/spec/simple_matrix_spec.cr
@@ -1,0 +1,23 @@
+require "./spec_helper"
+
+describe SHAInet::SimpleMatrix do
+  it "supports basic operations" do
+    a = SHAInet::SimpleMatrix.new(2, 2)
+    a[0,0] = 1.0; a[0,1] = 2.0
+    a[1,0] = 3.0; a[1,1] = 4.0
+
+    b = SHAInet::SimpleMatrix.new(2,2)
+    b[0,0] = 1.0; b[1,1] = 1.0
+
+    sum = a + b
+    sum[1,1].should eq(5.0)
+
+    prod = a * b
+    prod[0,0].should eq(1.0)
+    prod[1,1].should eq(4.0)
+
+    t = a.transpose
+    t[0,1].should eq(3.0)
+  end
+end
+

--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -1,0 +1,93 @@
+module SHAInet
+  class SimpleMatrix
+    property rows : Int32
+    property cols : Int32
+    getter data : Array(Float64)
+
+    def initialize(@rows : Int32, @cols : Int32, init : Float64 = 0.0)
+      @data = Array(Float64).new(@rows * @cols, init)
+    end
+
+    def self.zeros(rows : Int32, cols : Int32)
+      new(rows, cols, 0.0)
+    end
+
+    def self.ones(rows : Int32, cols : Int32)
+      new(rows, cols, 1.0)
+    end
+
+    def [](r : Int32, c : Int32)
+      @data[r * @cols + c]
+    end
+
+    def []=(r : Int32, c : Int32, v : Float64)
+      @data[r * @cols + c] = v
+    end
+
+    def +(other : SimpleMatrix)
+      raise ArgumentError.new("size mismatch") unless @rows == other.rows && @cols == other.cols
+      result = SimpleMatrix.new(@rows, @cols)
+      @rows.times do |i|
+        @cols.times do |j|
+          result[i, j] = self[i, j] + other[i, j]
+        end
+      end
+      result
+    end
+
+    def -(other : SimpleMatrix)
+      raise ArgumentError.new("size mismatch") unless @rows == other.rows && @cols == other.cols
+      result = SimpleMatrix.new(@rows, @cols)
+      @rows.times do |i|
+        @cols.times do |j|
+          result[i, j] = self[i, j] - other[i, j]
+        end
+      end
+      result
+    end
+
+    def *(other : SimpleMatrix)
+      raise ArgumentError.new("size mismatch") unless @cols == other.rows
+      result = SimpleMatrix.new(@rows, other.cols)
+      @rows.times do |i|
+        other.cols.times do |j|
+          sum = 0.0
+          @cols.times do |k|
+            sum += self[i, k] * other[k, j]
+          end
+          result[i, j] = sum
+        end
+      end
+      result
+    end
+
+    def *(scalar : Number)
+      result = SimpleMatrix.new(@rows, @cols)
+      @rows.times do |i|
+        @cols.times do |j|
+          result[i, j] = self[i, j] * scalar.to_f64
+        end
+      end
+      result
+    end
+
+    def transpose
+      result = SimpleMatrix.new(@cols, @rows)
+      @rows.times do |i|
+        @cols.times do |j|
+          result[j, i] = self[i, j]
+        end
+      end
+      result
+    end
+
+    def to_a
+      Array.new(@rows) do |i|
+        Array.new(@cols) do |j|
+          self[i, j]
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Summary
- add a lightweight `SimpleMatrix` class for Float64 matrices
- test matrix creation and operations

## Testing
- `crystal spec $(find spec -maxdepth 1 -name '*.cr' | tr '\n' ' ') --order random`

------
https://chatgpt.com/codex/tasks/task_e_685961354d1483319f1256ea6df6ea9b