### PR TITLE
Add basic transformer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,17 @@ sequence = ids.map { |id| [id.to_f64] }
 output = net.run(sequence).last
 ```
 
+Example use of a Transformer layer:
+
+```crystal
+net = SHAInet::Network.new
+net.add_layer(:input, 4)
+net.add_layer(:transformer, 4)
+net.add_layer(:output, 4)
+net.fully_connect
+out = net.run([[1.0, 0.0, 0.0, 0.0]]).first
+```
+
 Example of a Byte-Pair Encoding tokenizer:
 
 ```crystal

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+describe SHAInet::MultiHeadAttention do
+  it "trains to output constant values" do
+    attn = SHAInet::MultiHeadAttention.new(2, 1)
+    input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    target = SHAInet::SimpleMatrix.ones(2, 2)
+    500.times do
+      out = attn.forward(input)
+      diff = out - target
+      attn.backward(diff, 0.05)
+    end
+    out = attn.forward(input)
+    out[0, 0].should be_close(1.0, 0.1)
+    out[1, 1].should be_close(1.0, 0.1)
+  end
+end
+
+describe SHAInet::TransformerLayer do
+  it "overfits a tiny sequence" do
+    layer = SHAInet::TransformerLayer.new(2, 1, 4)
+    input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    target = SHAInet::SimpleMatrix.ones(2, 2)
+    500.times do
+      out = layer.forward(input)
+      diff = out - target
+      layer.backward(diff, 0.05)
+    end
+    out = layer.forward(input)
+    out[0, 0].should be_close(1.0, 0.1)
+    out[1, 1].should be_close(1.0, 0.1)
+  end
+end

--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -88,6 +88,60 @@ module SHAInet
         end
       end
     end
+
+    # Construct a matrix from a nested Array
+    def self.from_a(array : Array(Array(GenNum)))
+      rows = array.size
+      cols = array.first.size
+      m = SimpleMatrix.new(rows, cols)
+      rows.times do |i|
+        cols.times do |j|
+          m[i, j] = array[i][j].to_f64
+        end
+      end
+      m
+    end
+
+    # Fill the matrix with random values in the given range
+    def random_fill!(min : Float64 = -0.1, max : Float64 = 0.1)
+      @rows.times do |i|
+        @cols.times do |j|
+          self[i, j] = rand(min..max)
+        end
+      end
+      self
+    end
+
+    # Slice a range of columns from the matrix
+    def slice_cols(start_col : Int32, length : Int32)
+      result = SimpleMatrix.new(@rows, length)
+      @rows.times do |i|
+        length.times do |j|
+          result[i, j] = self[i, start_col + j]
+        end
+      end
+      result
+    end
+
+    # Set a range of columns in-place from another matrix
+    def set_cols!(start_col : Int32, other : SimpleMatrix)
+      raise ArgumentError.new("row mismatch") unless other.rows == @rows
+      other.cols.times do |j|
+        @rows.times do |i|
+          self[i, start_col + j] = other[i, j]
+        end
+      end
+    end
+
+    def clone
+      dup = SimpleMatrix.new(@rows, @cols)
+      @rows.times do |i|
+        @cols.times do |j|
+          dup[i, j] = self[i, j]
+        end
+      end
+      dup
+    end
   end
 end
 

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -1,0 +1,148 @@
+module SHAInet
+  class MultiHeadAttention
+    getter num_heads, d_model, head_dim
+    @head_dim : Int32
+    @w_q : SimpleMatrix
+    @w_k : SimpleMatrix
+    @w_v : SimpleMatrix
+    @w_o : SimpleMatrix
+    @grads_w_q : SimpleMatrix
+    @grads_w_k : SimpleMatrix
+    @grads_w_v : SimpleMatrix
+    @grads_w_o : SimpleMatrix
+    @x : SimpleMatrix?
+    @q_heads : Array(SimpleMatrix)
+    @k_heads : Array(SimpleMatrix)
+    @v_heads : Array(SimpleMatrix)
+    @attn : Array(SimpleMatrix)
+    @out : SimpleMatrix
+
+    getter w_q, w_k, w_v, w_o
+    property grads_w_q : SimpleMatrix
+    property grads_w_k : SimpleMatrix
+    property grads_w_v : SimpleMatrix
+    property grads_w_o : SimpleMatrix
+
+    def initialize(@d_model : Int32, @num_heads : Int32)
+      @head_dim = (@d_model // @num_heads)
+      @w_q = SimpleMatrix.new(@d_model, @d_model).random_fill!
+      @w_k = SimpleMatrix.new(@d_model, @d_model).random_fill!
+      @w_v = SimpleMatrix.new(@d_model, @d_model).random_fill!
+      @w_o = SimpleMatrix.new(@d_model, @d_model).random_fill!
+      @grads_w_q = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_k = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_v = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_o = SimpleMatrix.zeros(@d_model, @d_model)
+      @q_heads = [] of SimpleMatrix
+      @k_heads = [] of SimpleMatrix
+      @v_heads = [] of SimpleMatrix
+      @attn = [] of SimpleMatrix
+      @out = SimpleMatrix.zeros(1,1)
+    end
+
+    def forward(x : SimpleMatrix)
+      @x = x
+      q = x * @w_q
+      k = x * @w_k
+      v = x * @w_v
+
+      @q_heads = [] of SimpleMatrix
+      @k_heads = [] of SimpleMatrix
+      @v_heads = [] of SimpleMatrix
+      @attn = [] of SimpleMatrix
+      outputs = [] of SimpleMatrix
+
+      @num_heads.times do |h|
+        qs = q.slice_cols(h*@head_dim, @head_dim)
+        ks = k.slice_cols(h*@head_dim, @head_dim)
+        vs = v.slice_cols(h*@head_dim, @head_dim)
+        @q_heads << qs
+        @k_heads << ks
+        @v_heads << vs
+
+        scores = qs * ks.transpose * (1.0 / Math.sqrt(@head_dim.to_f))
+        attn = softmax_rows(scores)
+        @attn << attn
+        outputs << (attn * vs)
+      end
+
+      concat = SimpleMatrix.new(x.rows, @d_model)
+      @num_heads.times do |h|
+        concat.set_cols!(h*@head_dim, outputs[h])
+      end
+
+      @out = concat * @w_o
+      @out
+    end
+
+    def backward(d_out : SimpleMatrix, lr : Float64)
+      # Gradients for output projection
+      @grads_w_o = (@q_heads.size == 0 ? SimpleMatrix.zeros(@d_model, @d_model) : @grads_w_o)
+      @grads_w_o = @grads_w_o + ((@out.clone.transpose * d_out))
+      d_concat = d_out * @w_o.transpose
+
+      d_q_total = SimpleMatrix.zeros(@x.not_nil!.rows, @d_model)
+      d_k_total = SimpleMatrix.zeros(@x.not_nil!.rows, @d_model)
+      d_v_total = SimpleMatrix.zeros(@x.not_nil!.rows, @d_model)
+
+      @num_heads.times do |h|
+        d_head = d_concat.slice_cols(h*@head_dim, @head_dim)
+        attn = @attn[h]
+        vs = @v_heads[h]
+        qs = @q_heads[h]
+        ks = @k_heads[h]
+
+        d_attn = d_head * vs.transpose
+        d_vs = attn.transpose * d_head
+
+        # softmax gradient
+        d_scores = SimpleMatrix.zeros(attn.rows, attn.cols)
+        attn.rows.times do |i|
+          sum = 0.0
+          attn.cols.times do |j|
+            sum += attn[i,j] * d_attn[i,j]
+          end
+          attn.cols.times do |j|
+            d_scores[i,j] = attn[i,j]*(d_attn[i,j] - sum)
+          end
+        end
+        d_qs = d_scores * ks
+        d_ks = d_scores.transpose * qs
+
+        d_q_total.set_cols!(h*@head_dim, d_qs)
+        d_k_total.set_cols!(h*@head_dim, d_ks)
+        d_v_total.set_cols!(h*@head_dim, d_vs)
+      end
+
+      @grads_w_q = @grads_w_q + (@x.not_nil!.transpose * d_q_total)
+      @grads_w_k = @grads_w_k + (@x.not_nil!.transpose * d_k_total)
+      @grads_w_v = @grads_w_v + (@x.not_nil!.transpose * d_v_total)
+
+      d_input = d_q_total * @w_q.transpose + d_k_total * @w_k.transpose + d_v_total * @w_v.transpose
+
+      update_params(lr)
+      d_input
+    end
+
+    private def update_params(lr : Float64)
+      @w_q = @w_q - @grads_w_q * lr
+      @w_k = @w_k - @grads_w_k * lr
+      @w_v = @w_v - @grads_w_v * lr
+      @w_o = @w_o - @grads_w_o * lr
+      @grads_w_q = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_k = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_v = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_o = SimpleMatrix.zeros(@d_model, @d_model)
+    end
+
+    private def softmax_rows(m : SimpleMatrix)
+      result = SimpleMatrix.new(m.rows, m.cols)
+      m.rows.times do |i|
+        sum = 0.0
+        m.cols.times { |j| sum += Math.exp(m[i,j]) }
+        m.cols.times { |j| result[i,j] = Math.exp(m[i,j]) / sum }
+      end
+      result
+    end
+  end
+end

--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -1,0 +1,105 @@
+module SHAInet
+  class PositionWiseFF
+    getter w1, b1, w2, b2
+    @w1 : SimpleMatrix
+    @b1 : SimpleMatrix
+    @w2 : SimpleMatrix
+    @b2 : SimpleMatrix
+    @g_w1 : SimpleMatrix
+    @g_w2 : SimpleMatrix
+    @g_b1 : SimpleMatrix
+    @g_b2 : SimpleMatrix
+    @x : SimpleMatrix?
+    @h : SimpleMatrix
+    @out : SimpleMatrix
+
+    property g_w1 : SimpleMatrix
+    property g_w2 : SimpleMatrix
+    property g_b1 : SimpleMatrix
+    property g_b2 : SimpleMatrix
+
+    def initialize(d_model : Int32, hidden_dim : Int32)
+      @w1 = SimpleMatrix.new(d_model, hidden_dim).random_fill!
+      @b1 = SimpleMatrix.new(1, hidden_dim).random_fill!
+      @w2 = SimpleMatrix.new(hidden_dim, d_model).random_fill!
+      @b2 = SimpleMatrix.new(1, d_model).random_fill!
+      @g_w1 = SimpleMatrix.zeros(d_model, hidden_dim)
+      @g_w2 = SimpleMatrix.zeros(hidden_dim, d_model)
+      @g_b1 = SimpleMatrix.zeros(1, hidden_dim)
+      @g_b2 = SimpleMatrix.zeros(1, d_model)
+      @h = SimpleMatrix.zeros(1,1)
+      @out = SimpleMatrix.zeros(1,1)
+    end
+
+    def forward(x : SimpleMatrix)
+      @x = x
+      @h = x * @w1
+      @h.rows.times do |i|
+        @h.cols.times do |j|
+          @h[i,j] += @b1[0,j]
+        end
+      end
+      relu!(@h)
+      @out = @h * @w2
+      @out.rows.times do |i|
+        @out.cols.times do |j|
+          @out[i,j] += @b2[0,j]
+        end
+      end
+      @out
+    end
+
+    def backward(d_out : SimpleMatrix, lr : Float64)
+      dh = d_out * @w2.transpose
+      @g_w2 = @g_w2 + (@h.transpose * d_out)
+      db2 = SimpleMatrix.zeros(1, d_out.cols)
+      d_out.rows.times do |i|
+        d_out.cols.times do |j|
+          db2[0,j] += d_out[i,j]
+        end
+      end
+      @g_b2 = @g_b2 + db2
+      drelu = relu_grad(@h, dh)
+      @g_w1 = @g_w1 + (@x.not_nil!.transpose * drelu)
+      db1 = SimpleMatrix.zeros(1, drelu.cols)
+      drelu.rows.times do |i|
+        drelu.cols.times do |j|
+          db1[0,j] += drelu[i,j]
+        end
+      end
+      @g_b1 = @g_b1 + db1
+      d_input = drelu * @w1.transpose
+      update_params(lr)
+      d_input
+    end
+
+    private def update_params(lr : Float64)
+      @w1 = @w1 - @g_w1 * lr
+      @b1 = @b1 - @g_b1 * lr
+      @w2 = @w2 - @g_w2 * lr
+      @b2 = @b2 - @g_b2 * lr
+      @g_w1 = SimpleMatrix.zeros(@w1.rows, @w1.cols)
+      @g_w2 = SimpleMatrix.zeros(@w2.rows, @w2.cols)
+      @g_b1 = SimpleMatrix.zeros(@b1.rows, @b1.cols)
+      @g_b2 = SimpleMatrix.zeros(@b2.rows, @b2.cols)
+    end
+
+    private def relu!(m : SimpleMatrix)
+      m.rows.times do |i|
+        m.cols.times do |j|
+          m[i,j] = m[i,j] > 0 ? m[i,j] : 0.0
+        end
+      end
+    end
+
+    private def relu_grad(m : SimpleMatrix, grad : SimpleMatrix)
+      out = grad.clone
+      m.rows.times do |i|
+        m.cols.times do |j|
+          out[i,j] = m[i,j] > 0 ? grad[i,j] : 0.0
+        end
+      end
+      out
+    end
+  end
+end

--- a/src/shainet/transformer/transformer_layer.cr
+++ b/src/shainet/transformer/transformer_layer.cr
@@ -1,0 +1,28 @@
+module SHAInet
+  class TransformerLayer < Layer
+    getter mha : MultiHeadAttention
+    getter ffn : PositionWiseFF
+
+    def initialize(d_model : Int32, num_heads : Int32, ff_hidden : Int32)
+      super("memory", d_model, SHAInet.none)
+      @mha = MultiHeadAttention.new(d_model, num_heads)
+      @ffn = PositionWiseFF.new(d_model, ff_hidden)
+    end
+
+    def forward(x : SimpleMatrix)
+      attn_out = @mha.forward(x)
+      ff_out = @ffn.forward(attn_out)
+      ff_out
+    end
+
+    def backward(d_out : SimpleMatrix, lr : Float64)
+      d_attn = @ffn.backward(d_out, lr)
+      d_in = @mha.backward(d_attn, lr)
+      d_in
+    end
+
+    def neurons
+      [] of Neuron
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create simple multi-head attention and feed forward modules
- add a transformer layer and allow networks to build it
- expand SimpleMatrix with helper methods
- document basic transformer usage
- add a small spec exercising transformer layer
- expand transformer spec with simple training checks

## Testing
- `crystal spec spec/transformer_spec.cr`
- `crystal spec spec/lstm_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_685968c8bfb48331b5a3c61c5552d014