### PR TITLE
Add gradient accumulation for transformers

### DIFF
--- a/spec/lstm_spec.cr
+++ b/spec/lstm_spec.cr
@@ -2,6 +2,7 @@ require "./spec_helper"
 
 describe SHAInet::LSTMLayer do
   it "runs forward and backward through a simple sequence" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
     net = SHAInet::Network.new
     net.add_layer(:input, 1, :memory, SHAInet.none)
     net.add_layer(:lstm, 1)
@@ -20,6 +21,7 @@ describe SHAInet::LSTMLayer do
   end
 
   it "learns to predict the last value of a sequence" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
     net = SHAInet::Network.new
     net.add_layer(:input, 1, :memory, SHAInet.none)
     net.add_layer(:lstm, 1)

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -2,13 +2,15 @@ require "./spec_helper"
 
 describe SHAInet::MultiHeadAttention do
   it "trains to output constant values" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
     attn = SHAInet::MultiHeadAttention.new(2, 1)
     input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
     target = SHAInet::SimpleMatrix.ones(2, 2)
-    500.times do
+    1000.times do
       out = attn.forward(input)
       diff = out - target
-      attn.backward(diff, 0.05)
+      attn.backward(diff)
+      attn.apply_gradients(0.05)
     end
     out = attn.forward(input)
     out[0, 0].should be_close(1.0, 0.1)
@@ -18,16 +20,35 @@ end
 
 describe SHAInet::TransformerLayer do
   it "overfits a tiny sequence" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
     layer = SHAInet::TransformerLayer.new(2, 1, 4)
     input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
     target = SHAInet::SimpleMatrix.ones(2, 2)
-    500.times do
+    1000.times do
       out = layer.forward(input)
       diff = out - target
-      layer.backward(diff, 0.05)
+      layer.backward(diff)
+      layer.apply_gradients(0.05)
     end
     out = layer.forward(input)
     out[0, 0].should be_close(1.0, 0.1)
     out[1, 1].should be_close(1.0, 0.1)
+  end
+end
+
+describe "Network with TransformerLayer" do
+  it "can overfit a small sequence" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2, :memory, SHAInet.none)
+    net.add_layer(:transformer, 2)
+    net.add_layer(:output, 2, :memory, SHAInet.none)
+    training = [ [[[1.0, 0.0]], [1.0, 1.0]] ]
+    net.learning_rate = 0.1
+    net.train(data: training, training_type: :sgdm,
+      epochs: 2000, mini_batch_size: 1, log_each: 2000)
+    out = net.run([[1.0, 0.0]]).last
+    out[0].should be_close(1.0, 0.1)
+    out[1].should be_close(1.0, 0.1)
   end
 end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -285,6 +285,7 @@ module SHAInet
           @w_gradient = Array(Float64).new(@all_synapses.size) { 0.0 }
           @b_gradient = Array(Float64).new(@all_neurons.size) { 0.0 }
           @lstm_layers.each &.zero_gate_gradients
+          @transformer_layers.each &.zero_gradients
 
           # Go over each data point and collect gradients of weights/biases
           # based on each specific example
@@ -319,7 +320,7 @@ module SHAInet
             # Propogate the errors backwards through the hidden layers
             @hidden_layers.reverse_each do |l|
               if l.is_a?(TransformerLayer)
-                l.as(TransformerLayer).backward(@transformer_error, @learning_rate)
+                l.as(TransformerLayer).backward(@transformer_error)
               else
                 l.neurons.each { |neuron| neuron.hidden_error_prop }
               end
@@ -375,6 +376,7 @@ module SHAInet
           update_weights(training_type)
           update_biases(training_type)
           update_lstm_gates(training_type)
+          update_transformer_layers
 
           # Update epoch status
           epoch_mse += @mse
@@ -534,6 +536,12 @@ module SHAInet
     def update_lstm_gates(learn_type : Symbol | String)
       @lstm_layers.each do |layer|
         layer.update_gate_params(@learning_rate)
+      end
+    end
+
+    def update_transformer_layers
+      @transformer_layers.each do |layer|
+        layer.apply_gradients(@learning_rate)
       end
     end
 

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -75,7 +75,7 @@ module SHAInet
       @out
     end
 
-    def backward(d_out : SimpleMatrix, lr : Float64)
+    def backward(d_out : SimpleMatrix)
       # Gradients for output projection
       @grads_w_o = (@q_heads.size == 0 ? SimpleMatrix.zeros(@d_model, @d_model) : @grads_w_o)
       @grads_w_o = @grads_w_o + ((@out.clone.transpose * d_out))
@@ -120,15 +120,21 @@ module SHAInet
 
       d_input = d_q_total * @w_q.transpose + d_k_total * @w_k.transpose + d_v_total * @w_v.transpose
 
-      update_params(lr)
       d_input
     end
 
-    private def update_params(lr : Float64)
+    def apply_gradients(lr : Float64)
       @w_q = @w_q - @grads_w_q * lr
       @w_k = @w_k - @grads_w_k * lr
       @w_v = @w_v - @grads_w_v * lr
       @w_o = @w_o - @grads_w_o * lr
+      @grads_w_q = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_k = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_v = SimpleMatrix.zeros(@d_model, @d_model)
+      @grads_w_o = SimpleMatrix.zeros(@d_model, @d_model)
+    end
+
+    def zero_gradients
       @grads_w_q = SimpleMatrix.zeros(@d_model, @d_model)
       @grads_w_k = SimpleMatrix.zeros(@d_model, @d_model)
       @grads_w_v = SimpleMatrix.zeros(@d_model, @d_model)

--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -49,7 +49,7 @@ module SHAInet
       @out
     end
 
-    def backward(d_out : SimpleMatrix, lr : Float64)
+    def backward(d_out : SimpleMatrix)
       dh = d_out * @w2.transpose
       @g_w2 = @g_w2 + (@h.transpose * d_out)
       db2 = SimpleMatrix.zeros(1, d_out.cols)
@@ -69,15 +69,21 @@ module SHAInet
       end
       @g_b1 = @g_b1 + db1
       d_input = drelu * @w1.transpose
-      update_params(lr)
       d_input
     end
 
-    private def update_params(lr : Float64)
+    def apply_gradients(lr : Float64)
       @w1 = @w1 - @g_w1 * lr
       @b1 = @b1 - @g_b1 * lr
       @w2 = @w2 - @g_w2 * lr
       @b2 = @b2 - @g_b2 * lr
+      @g_w1 = SimpleMatrix.zeros(@w1.rows, @w1.cols)
+      @g_w2 = SimpleMatrix.zeros(@w2.rows, @w2.cols)
+      @g_b1 = SimpleMatrix.zeros(@b1.rows, @b1.cols)
+      @g_b2 = SimpleMatrix.zeros(@b2.rows, @b2.cols)
+    end
+
+    def zero_gradients
       @g_w1 = SimpleMatrix.zeros(@w1.rows, @w1.cols)
       @g_w2 = SimpleMatrix.zeros(@w2.rows, @w2.cols)
       @g_b1 = SimpleMatrix.zeros(@b1.rows, @b1.cols)

--- a/src/shainet/transformer/transformer_layer.cr
+++ b/src/shainet/transformer/transformer_layer.cr
@@ -15,10 +15,20 @@ module SHAInet
       ff_out
     end
 
-    def backward(d_out : SimpleMatrix, lr : Float64)
-      d_attn = @ffn.backward(d_out, lr)
-      d_in = @mha.backward(d_attn, lr)
+    def backward(d_out : SimpleMatrix)
+      d_attn = @ffn.backward(d_out)
+      d_in = @mha.backward(d_attn)
       d_in
+    end
+
+    def apply_gradients(lr : Float64)
+      @ffn.apply_gradients(lr)
+      @mha.apply_gradients(lr)
+    end
+
+    def zero_gradients
+      @ffn.zero_gradients
+      @mha.zero_gradients
     end
 
     def neurons


### PR DESCRIPTION
## Summary
- implement gradient accumulation and parameter updates for TransformerLayer components
- expose methods to zero and apply gradients
- update Network training loop to use new transformer gradient flow
- seed transformer and LSTM specs and expand training iterations
- add integration spec for network with transformer layer

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_68599262801883319e475a63a9dd1707