### PR TITLE
Implement amplifier neuron type with tests

### DIFF
--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -148,6 +148,39 @@ describe SHAInet::Network do
     (xor.run(input: [1, 1], stealth: false).first < 0.1).should eq(true)
   end
 
+  it "Figure out XOR with amplifier neurons" do
+    puts "\n"
+    training_data = [
+      [[0, 0], [0]],
+      [[1, 0], [1]],
+      [[0, 1], [1]],
+      [[1, 1], [0]],
+    ]
+
+    xor = SHAInet::Network.new
+
+    xor.add_layer(:input, 2, "amplifier", SHAInet.sigmoid)
+    xor.add_layer(:hidden, 3, "amplifier", SHAInet.sigmoid)
+    xor.add_layer(:output, 1, "amplifier", SHAInet.sigmoid)
+    xor.fully_connect
+
+    xor.learning_rate = 0.7
+    xor.momentum = 0.3
+
+    xor.train(
+      data: training_data,
+      training_type: :sgdm,
+      cost_function: :mse,
+      epochs: 5000,
+      error_threshold: 1e-9,
+      log_each: 1000)
+
+    (xor.run(input: [0, 0], stealth: true).first < 0.1).should eq(true)
+    (xor.run(input: [1, 0], stealth: true).first > 0.9).should eq(true)
+    (xor.run(input: [0, 1], stealth: true).first > 0.9).should eq(true)
+    (xor.run(input: [1, 1], stealth: true).first < 0.1).should eq(true)
+  end
+
   puts "############################################################"
 
   it "Supports both Symbols or Strings as input params" do

--- a/spec/neuron_spec.cr
+++ b/spec/neuron_spec.cr
@@ -4,7 +4,32 @@ describe SHAInet::Neuron do
   puts "############################################################"
   it "Initialize neuron" do
     puts "\n"
-    neuron = SHAInet::Neuron.new("memory")
-    neuron.should be_a(SHAInet::Neuron)
+    SHAInet::NEURON_TYPES.each do |type|
+      neuron = SHAInet::Neuron.new(type)
+      neuron.should be_a(SHAInet::Neuron)
+    end
+  end
+
+  it "propagates based on neuron type" do
+    puts "\n"
+    src = SHAInet::Neuron.new("memory")
+    dest = SHAInet::Neuron.new("memory")
+
+    syn = SHAInet::Synapse.new(src, dest)
+    syn.weight = 1.0
+    src.activation = 1.0
+    syn.propagate_forward.should eq(1.0)
+
+    src.n_type = "eraser"
+    syn.propagate_forward.should eq(-1.0)
+
+    src.n_type = "amplifier"
+    syn.propagate_forward.should eq(2.0)
+
+    src.n_type = "fader"
+    syn.propagate_forward.should eq(0.5)
+
+    src.n_type = "sensor"
+    syn.propagate_forward.should eq(1.0)
   end
 end

--- a/src/shainet/basic/synapse.cr
+++ b/src/shainet/basic/synapse.cr
@@ -33,6 +33,12 @@ module SHAInet
         new_memory
       when "eraser"
         (-1)*new_memory
+      when "amplifier"
+        new_memory*2
+      when "fader"
+        new_memory*0.5
+      when "sensor"
+        @source_neuron.activation
       else
         raise "Other types of neurons are not supported yet!"
       end


### PR DESCRIPTION
## Summary
- implement additional neuron behaviors for amplifier, fader, and sensor
- extend neuron specs to cover all neuron types and check propagation logic
- add network test showing amplifier neurons can learn XOR

## Testing
- `crystal spec -v`

------
https://chatgpt.com/codex/tasks/task_e_68599d7868508331b2c746a36109d804