### PR TITLE
Add PyTorch loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,32 @@ cross‑entropy loss.
 crystal run examples/llm_sample.cr
 ```
 
+### Loading a PyTorch model
+
+SHAInet can import simple sequential models exported from PyTorch as TorchScript.
+First export your model from Python:
+
+```python
+import torch
+
+model = torch.nn.Sequential(
+    torch.nn.Linear(2, 3),
+    torch.nn.ReLU(),
+    torch.nn.Linear(3, 1)
+)
+example = torch.randn(1, 2)
+traced = torch.jit.trace(model, example)
+traced.save("model.pt")
+```
+
+Then load the file in Crystal:
+
+```crystal
+net = SHAInet::Network.new
+net.load_from_pt("model.pt")
+output = net.run([1.0, 2.0])
+```
+
 ### Possible Future Features
   - [x] RNN (recurant neural network)
   - [x] LSTM (long-short term memory)

--- a/scripts/build_simple_model.py
+++ b/scripts/build_simple_model.py
@@ -1,0 +1,23 @@
+import sys
+import warnings
+try:
+    import torch
+except Exception as e:
+    sys.stderr.write("PyTorch not installed: %s\n" % e)
+    sys.exit(1)
+
+warnings.filterwarnings("ignore")
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: build_simple_model.py <output.pt>\n")
+    sys.exit(1)
+
+torch.manual_seed(0)
+model = torch.nn.Sequential(
+    torch.nn.Linear(2, 3),
+    torch.nn.ReLU(),
+    torch.nn.Linear(3, 1),
+)
+example = torch.randn(1, 2)
+traced = torch.jit.trace(model, example)
+traced.save(sys.argv[1])

--- a/scripts/pt_forward.py
+++ b/scripts/pt_forward.py
@@ -1,0 +1,26 @@
+import sys
+import warnings
+try:
+    import torch
+except Exception as e:
+    sys.stderr.write("PyTorch not installed: %s\n" % e)
+    sys.exit(1)
+
+warnings.filterwarnings("ignore")
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: pt_forward.py <model.pt>\n")
+    sys.exit(1)
+
+model = torch.jit.load(sys.argv[1], map_location='cpu')
+model.eval()
+with torch.no_grad():
+    inp = torch.tensor([1.0, 2.0])
+    out = model(inp)
+    if hasattr(out, 'tolist'):
+        val = out.tolist()
+        if isinstance(val, list):
+            val = val[0]
+    else:
+        val = float(out)
+    print(val)

--- a/scripts/pt_to_json.py
+++ b/scripts/pt_to_json.py
@@ -1,0 +1,31 @@
+import json
+import sys
+import warnings
+
+try:
+    import torch
+except Exception as e:
+    sys.stderr.write("PyTorch not installed: %s\n" % e)
+    sys.exit(1)
+
+warnings.filterwarnings("ignore")
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: pt_to_json.py <model.pt>\n")
+    sys.exit(1)
+
+model = torch.jit.load(sys.argv[1], map_location="cpu")
+state = model.state_dict()
+keys = list(state.keys())
+keys.sort()
+
+layers = []
+for key in keys:
+    if key.endswith(".weight"):
+        name = key[:-7]
+        weight = state[key].cpu().tolist()
+        bias = state.get(name + ".bias")
+        bias_list = bias.cpu().tolist() if bias is not None else []
+        layers.append({"name": name, "weight": weight, "bias": bias_list})
+
+print(json.dumps({"layers": layers}))

--- a/spec/pytorch_loader_spec.cr
+++ b/spec/pytorch_loader_spec.cr
@@ -1,0 +1,32 @@
+require "./spec_helper"
+
+describe SHAInet::Network do
+  it "loads a simple TorchScript model" do
+    tmp = File.tempfile("model", ".pt")
+    model = tmp.path
+    tmp.close
+    build_err = IO::Memory.new
+    status = Process.run(
+      "python3",
+      ["-W", "ignore", "#{__DIR__}/../scripts/build_simple_model.py", model],
+      error: build_err
+    )
+    status.success?.should eq(true), build_err.to_s
+    net = SHAInet::Network.new
+    expect_out = IO::Memory.new
+    expect_err = IO::Memory.new
+    status = Process.run(
+      "python3",
+      ["-W", "ignore", "#{__DIR__}/../scripts/pt_forward.py", model],
+      output: expect_out,
+      error: expect_err
+    )
+    status.success?.should eq(true), expect_err.to_s
+    expected = expect_out.to_s.to_f
+
+    net.load_from_pt(model)
+    output = net.run([1.0, 2.0]).first
+    (output - expected).abs.should be < 1e-3
+    File.delete(model)
+  end
+end

--- a/src/shainet/math/functions.cr
+++ b/src/shainet/math/functions.cr
@@ -33,6 +33,10 @@ module SHAInet
     ->(value : GenNum) { {_l_relu(value), _l_relu_prime(value)} }
   end
 
+  def self.identity : ActivationFunction # Output range (-inf..inf)
+    ->(value : GenNum) { {value.to_f64, 1.0} }
+  end
+
   # # Activation functions # #
 
   def self._sigmoid(value : GenNum) : Float64 # Output range (0..1)

--- a/src/shainet/pytorch_import.cr
+++ b/src/shainet/pytorch_import.cr
@@ -1,0 +1,19 @@
+require "json"
+
+module SHAInet
+  module PyTorchImport
+    # Returns JSON data describing sequential linear layers.
+    def self.load(file_path : String) : JSON::Any
+      script = File.join(__DIR__, "../../scripts/pt_to_json.py")
+      output = IO::Memory.new
+      status = Process.run(
+        "python3",
+        [script, file_path],
+        output: output,
+        error: Process::Redirect::Close
+      )
+      raise "Failed to convert TorchScript" unless status.success?
+      JSON.parse(output.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add helper scripts to convert TorchScript models to JSON and forward them in Python
- support importing TorchScript models via `PyTorchImport`
- add `Network#load_from_pt` to build a network from the converted data
- remove stored TorchScript file and generate it dynamically in spec
- document PyTorch import usage in README
- add spec verifying TorchScript import

## Testing
- `crystal spec --order=random`


------
https://chatgpt.com/codex/tasks/task_e_685a701863088331aa4c6dd642501c5f