### PR TITLE
Add transformer positional encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,13 @@ cross‑entropy loss.
 crystal run examples/llm_sample.cr
 ```
 
+An additional example `examples/transformer_pe.cr` demonstrates using a
+`TransformerLayer` with sinusoidal positional encodings.
+
+```bash
+crystal run examples/transformer_pe.cr
+```
+
 ### Loading a PyTorch model
 
 SHAInet can import simple sequential models exported from PyTorch as TorchScript.

--- a/examples/transformer_pe.cr
+++ b/examples/transformer_pe.cr
@@ -1,0 +1,25 @@
+require "../src/shainet"
+
+# Simple demonstration of using a Transformer layer with sinusoidal positional encoding.
+
+# Create a tiny Transformer layer
+layer = SHAInet::TransformerLayer.new(2, 1, 4)
+
+# Two-step input sequence (2 x 2 matrix)
+input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+
+# Generate positional encodings matching the input size
+pos_enc = SHAInet::PositionalEncoding.sinusoidal(input.rows, input.cols)
+layer.positional_encoding = pos_enc
+
+# Train the layer to output ones
+target = SHAInet::SimpleMatrix.ones(2, 2)
+1000.times do
+  out = layer.forward(input)
+  diff = out - target
+  layer.backward(diff)
+  layer.apply_gradients(0.05)
+end
+
+puts "Output after training:"
+pp layer.forward(input).to_a

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -18,11 +18,40 @@ describe SHAInet::MultiHeadAttention do
   end
 end
 
+describe SHAInet::PositionalEncoding do
+  it "generates sinusoidal values" do
+    pe = SHAInet::PositionalEncoding.sinusoidal(3, 4)
+    pe.rows.should eq(3)
+    pe.cols.should eq(4)
+    pe[0, 0].should be_close(0.0, 0.0001)
+    pe[0, 1].should be_close(1.0, 0.0001)
+    pe[1, 0].should be_close(Math.sin(1.0), 0.0001)
+    pe[1, 1].should be_close(Math.cos(1.0), 0.0001)
+  end
+end
+
 describe SHAInet::TransformerLayer do
   it "overfits a tiny sequence" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     layer = SHAInet::TransformerLayer.new(2, 1, 4)
     input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    target = SHAInet::SimpleMatrix.ones(2, 2)
+    1000.times do
+      out = layer.forward(input)
+      diff = out - target
+      layer.backward(diff)
+      layer.apply_gradients(0.05)
+    end
+    out = layer.forward(input)
+    out[0, 0].should be_close(1.0, 0.1)
+    out[1, 1].should be_close(1.0, 0.1)
+  end
+
+  it "overfits with positional encoding" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+    layer = SHAInet::TransformerLayer.new(2, 1, 4)
+    input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    layer.positional_encoding = SHAInet::PositionalEncoding.sinusoidal(2, 2)
     target = SHAInet::SimpleMatrix.ones(2, 2)
     1000.times do
       out = layer.forward(input)
@@ -43,7 +72,7 @@ describe "Network with TransformerLayer" do
     net.add_layer(:input, 2, :memory, SHAInet.none)
     net.add_layer(:transformer, 2)
     net.add_layer(:output, 2, :memory, SHAInet.none)
-    training = [ [[[1.0, 0.0]], [1.0, 1.0]] ]
+    training = [[[[1.0, 0.0]], [1.0, 1.0]]]
     net.learning_rate = 0.1
     net.train(data: training, training_type: :sgdm,
       epochs: 2000, mini_batch_size: 1, log_each: 2000)

--- a/src/shainet/transformer/positional_encoding.cr
+++ b/src/shainet/transformer/positional_encoding.cr
@@ -1,0 +1,21 @@
+module SHAInet
+  # Generates sinusoidal positional encodings as described in "Attention is All You Need".
+  # Returns a SimpleMatrix of shape (max_len, d_model).
+  class PositionalEncoding
+    def self.sinusoidal(max_len : Int32, d_model : Int32) : SimpleMatrix
+      pe = SimpleMatrix.new(max_len, d_model)
+      max_len.times do |pos|
+        d_model.times do |i|
+          div_term = 1.0 / (10000.0 ** ((2 * (i // 2)).to_f64 / d_model))
+          angle = pos.to_f64 * div_term
+          if i.even?
+            pe[pos, i] = Math.sin(angle)
+          else
+            pe[pos, i] = Math.cos(angle)
+          end
+        end
+      end
+      pe
+    end
+  end
+end

--- a/src/shainet/transformer/transformer_layer.cr
+++ b/src/shainet/transformer/transformer_layer.cr
@@ -2,15 +2,23 @@ module SHAInet
   class TransformerLayer < Layer
     getter mha : MultiHeadAttention
     getter ffn : PositionWiseFF
+    property positional_encoding : SimpleMatrix?
 
     def initialize(d_model : Int32, num_heads : Int32, ff_hidden : Int32)
       super("memory", d_model, SHAInet.none)
       @mha = MultiHeadAttention.new(d_model, num_heads)
       @ffn = PositionWiseFF.new(d_model, ff_hidden)
+      @positional_encoding = nil
     end
 
-    def forward(x : SimpleMatrix)
-      attn_out = @mha.forward(x)
+    def forward(x : SimpleMatrix, pe : SimpleMatrix? = nil)
+      input = if enc = (pe || @positional_encoding)
+                raise "positional encoding size mismatch" unless enc.rows == x.rows && enc.cols == x.cols
+                x + enc
+              else
+                x
+              end
+      attn_out = @mha.forward(input)
       ff_out = @ffn.forward(attn_out)
       ff_out
     end


### PR DESCRIPTION
## Summary
- implement `PositionalEncoding` for sinusoidal embeddings
- allow `TransformerLayer#forward` to optionally use positional encodings
- add example demonstrating training with positional encodings
- test positional encoding functionality and training convergence
- document positional encoding support in README

## Testing
- `crystal spec` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d0fda2483319ad703e8592f5e15