### PR TITLE
Add layer normalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ label = {
   - [x] Simple recurrent layers
   - [x] LSTM layers
   - [x] Embedding layers
+  - [x] Layer normalization for transformer layers
   - [ ] Add support for multiple neuron types.
   - [ ] Bind and use CUDA (GPU acceleration)
   - [ ] graphic printout of network architecture.

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -1,5 +1,26 @@
 require "./spec_helper"
 
+describe SHAInet::LayerNorm do
+  it "normalizes rows" do
+    ln = SHAInet::LayerNorm.new(2)
+    x = SHAInet::SimpleMatrix.from_a([[1.0, 3.0], [2.0, 0.0]])
+    out = ln.forward(x)
+    out.rows.times do |i|
+      mean = 0.0
+      var = 0.0
+      out.cols.times { |j| mean += out[i, j] }
+      mean /= out.cols
+      out.cols.times do |j|
+        diff = out[i, j] - mean
+        var += diff*diff
+      end
+      var /= out.cols
+      mean.should be_close(0.0, 1e-6)
+      var.should be_close(1.0, 1e-4)
+    end
+  end
+end
+
 describe SHAInet::MultiHeadAttention do
   it "trains to output constant values" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -1,0 +1,98 @@
+module SHAInet
+  class LayerNorm
+    getter gamma : SimpleMatrix
+    getter beta : SimpleMatrix
+    property g_gamma : SimpleMatrix
+    property g_beta : SimpleMatrix
+
+    @epsilon : Float64
+    @x : SimpleMatrix?
+    @mean : SimpleMatrix
+    @var : SimpleMatrix
+    @norm : SimpleMatrix
+
+    def initialize(d_model : Int32, epsilon : Float64 = 1e-5)
+      @gamma = SimpleMatrix.ones(1, d_model)
+      @beta = SimpleMatrix.zeros(1, d_model)
+      @g_gamma = SimpleMatrix.zeros(1, d_model)
+      @g_beta = SimpleMatrix.zeros(1, d_model)
+      @epsilon = epsilon
+      @mean = SimpleMatrix.zeros(1, 1)
+      @var = SimpleMatrix.zeros(1, 1)
+      @norm = SimpleMatrix.zeros(1, 1)
+    end
+
+    def forward(x : SimpleMatrix)
+      @x = x
+      rows = x.rows
+      cols = x.cols
+      @mean = SimpleMatrix.new(rows, 1)
+      @var = SimpleMatrix.new(rows, 1)
+      @norm = SimpleMatrix.new(rows, cols)
+      out = SimpleMatrix.new(rows, cols)
+      rows.times do |i|
+        mean = 0.0
+        cols.times { |j| mean += x[i, j] }
+        mean /= cols
+        @mean[i, 0] = mean
+        var = 0.0
+        cols.times do |j|
+          diff = x[i, j] - mean
+          var += diff*diff
+        end
+        var /= cols
+        @var[i, 0] = var
+        denom = Math.sqrt(var + @epsilon)
+        cols.times do |j|
+          n = (x[i, j] - mean) / denom
+          @norm[i, j] = n
+          out[i, j] = n * @gamma[0, j] + @beta[0, j]
+        end
+      end
+      out
+    end
+
+    def backward(d_out : SimpleMatrix)
+      x = @x.not_nil!
+      rows = x.rows
+      cols = x.cols
+      d_gamma = SimpleMatrix.zeros(1, cols)
+      d_beta = SimpleMatrix.zeros(1, cols)
+      d_x = SimpleMatrix.new(rows, cols)
+      rows.times do |i|
+        denom = Math.sqrt(@var[i, 0] + @epsilon)
+        inv = 1.0 / denom
+        col_f = cols.to_f64
+        sum_dout_gamma = 0.0
+        sum_dout_gamma_norm = 0.0
+        cols.times do |j|
+          doutg = d_out[i, j] * @gamma[0, j]
+          sum_dout_gamma += doutg
+          sum_dout_gamma_norm += doutg * (x[i, j] - @mean[i, 0])
+          d_gamma[0, j] += d_out[i, j] * @norm[i, j]
+          d_beta[0, j] += d_out[i, j]
+        end
+        cols.times do |j|
+          xm = x[i, j] - @mean[i, 0]
+          doutg = d_out[i, j] * @gamma[0, j]
+          d_x[i, j] = inv * (doutg - sum_dout_gamma/col_f - xm * inv*inv / col_f * sum_dout_gamma_norm)
+        end
+      end
+      @g_gamma = @g_gamma + d_gamma
+      @g_beta = @g_beta + d_beta
+      d_x
+    end
+
+    def apply_gradients(lr : Float64)
+      @gamma = @gamma - @g_gamma * lr
+      @beta = @beta - @g_beta * lr
+      @g_gamma = SimpleMatrix.zeros(@gamma.rows, @gamma.cols)
+      @g_beta = SimpleMatrix.zeros(@beta.rows, @beta.cols)
+    end
+
+    def zero_gradients
+      @g_gamma = SimpleMatrix.zeros(@gamma.rows, @gamma.cols)
+      @g_beta = SimpleMatrix.zeros(@beta.rows, @beta.cols)
+    end
+  end
+end

--- a/src/shainet/transformer/transformer_layer.cr
+++ b/src/shainet/transformer/transformer_layer.cr
@@ -2,12 +2,16 @@ module SHAInet
   class TransformerLayer < Layer
     getter mha : MultiHeadAttention
     getter ffn : PositionWiseFF
+    getter norm1 : LayerNorm
+    getter norm2 : LayerNorm
     property positional_encoding : SimpleMatrix?
 
     def initialize(d_model : Int32, num_heads : Int32, ff_hidden : Int32)
       super("memory", d_model, SHAInet.none)
       @mha = MultiHeadAttention.new(d_model, num_heads)
       @ffn = PositionWiseFF.new(d_model, ff_hidden)
+      @norm1 = LayerNorm.new(d_model)
+      @norm2 = LayerNorm.new(d_model)
       @positional_encoding = nil
     end
 
@@ -19,24 +23,30 @@ module SHAInet
                 x
               end
       attn_out = @mha.forward(input)
-      ff_out = @ffn.forward(attn_out)
-      ff_out
+      normed = @norm1.forward(attn_out)
+      ff_out = @ffn.forward(normed)
+      @norm2.forward(ff_out)
     end
 
     def backward(d_out : SimpleMatrix)
-      d_attn = @ffn.backward(d_out)
-      d_in = @mha.backward(d_attn)
-      d_in
+      d_norm2 = @norm2.backward(d_out)
+      d_ff = @ffn.backward(d_norm2)
+      d_norm1 = @norm1.backward(d_ff)
+      @mha.backward(d_norm1)
     end
 
     def apply_gradients(lr : Float64)
       @ffn.apply_gradients(lr)
       @mha.apply_gradients(lr)
+      @norm1.apply_gradients(lr)
+      @norm2.apply_gradients(lr)
     end
 
     def zero_gradients
       @ffn.zero_gradients
       @mha.zero_gradients
+      @norm1.zero_gradients
+      @norm2.zero_gradients
     end
 
     def neurons


### PR DESCRIPTION
## Summary
- implement `LayerNorm` for transformer models
- integrate it into `TransformerLayer`
- test layer norm and transformer training
- mention the new feature in the README

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685aa02b0c688331a2c03b6aea6cce7f