### PR TITLE
Add mask support to MultiHeadAttention

### DIFF
--- a/examples/transformer_pe.cr
+++ b/examples/transformer_pe.cr
@@ -12,14 +12,20 @@ input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
 pos_enc = SHAInet::PositionalEncoding.sinusoidal(input.rows, input.cols)
 layer.positional_encoding = pos_enc
 
+# Causal mask so each position attends only to itself and previous ones
+mask = SHAInet::SimpleMatrix.from_a([
+  [0.0, -1e9],
+  [0.0, 0.0]
+])
+
 # Train the layer to output ones
 target = SHAInet::SimpleMatrix.ones(2, 2)
 1000.times do
-  out = layer.forward(input)
+  out = layer.forward(input, nil, mask)
   diff = out - target
   layer.backward(diff)
   layer.apply_gradients(0.05)
 end
 
 puts "Output after training:"
-pp layer.forward(input).to_a
+pp layer.forward(input, nil, mask).to_a

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -37,6 +37,20 @@ describe SHAInet::MultiHeadAttention do
     out[0, 0].should be_close(1.0, 0.1)
     out[1, 1].should be_close(1.0, 0.1)
   end
+
+  it "respects an attention mask" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+    attn = SHAInet::MultiHeadAttention.new(2, 1)
+    input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    mask = SHAInet::SimpleMatrix.from_a([[0.0, -1e9], [-1e9, 0.0]])
+    out = attn.forward(input, mask)
+    expected = (input * attn.w_v) * attn.w_o
+    out.rows.times do |i|
+      out.cols.times do |j|
+        out[i, j].should be_close(expected[i, j], 1e-6)
+      end
+    end
+  end
 end
 
 describe SHAInet::PositionalEncoding do

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -40,7 +40,7 @@ module SHAInet
       @out = SimpleMatrix.zeros(1,1)
     end
 
-    def forward(x : SimpleMatrix)
+    def forward(x : SimpleMatrix, mask : SimpleMatrix? = nil)
       @x = x
       q = x * @w_q
       k = x * @w_k
@@ -61,6 +61,10 @@ module SHAInet
         @v_heads << vs
 
         scores = qs * ks.transpose * (1.0 / Math.sqrt(@head_dim.to_f))
+        if m = mask
+          raise "mask size mismatch" unless m.rows == scores.rows && m.cols == scores.cols
+          scores = scores + m
+        end
         attn = softmax_rows(scores)
         @attn << attn
         outputs << (attn * vs)

--- a/src/shainet/transformer/transformer_layer.cr
+++ b/src/shainet/transformer/transformer_layer.cr
@@ -15,14 +15,14 @@ module SHAInet
       @positional_encoding = nil
     end
 
-    def forward(x : SimpleMatrix, pe : SimpleMatrix? = nil)
+    def forward(x : SimpleMatrix, pe : SimpleMatrix? = nil, mask : SimpleMatrix? = nil)
       input = if enc = (pe || @positional_encoding)
                 raise "positional encoding size mismatch" unless enc.rows == x.rows && enc.cols == x.cols
                 x + enc
               else
                 x
               end
-      attn_out = @mha.forward(input)
+      attn_out = @mha.forward(input, mask)
       normed = @norm1.forward(attn_out)
       ff_out = @ffn.forward(normed)
       @norm2.forward(ff_out)


### PR DESCRIPTION
## Summary
- allow MultiHeadAttention `forward` to take an optional mask
- propagate mask support through TransformerLayer
- demonstrate a causal mask in `examples/transformer_pe.cr`
- test that masked positions don't influence attention output

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685aa52739bc833190aaaeb5afed6261