### PR TITLE
Add gradient clipping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ xor.fully_connect
 # Adjust network parameters
 xor.learning_rate = 0.7
 xor.momentum = 0.3
+xor.clip_threshold = 5.0
 
 # data, training_type, cost_function, activation_function, epochs, error_threshold (sum of errors), learning_rate, momentum)
 xor.train(
@@ -86,6 +87,7 @@ iris.fully_connect
 # Adjust network parameters
 xor.learning_rate = 0.7
 xor.momentum = 0.3
+xor.clip_threshold = 5.0
 
 # Train the network
 iris.train_batch(

--- a/spec/clip_threshold_spec.cr
+++ b/spec/clip_threshold_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+
+describe SHAInet::Network do
+  it "clips gradients when updating parameters" do
+    nn = SHAInet::Network.new
+    nn.add_layer(:input, 1, :memory, SHAInet.none)
+    nn.add_layer(:output, 1, :memory, SHAInet.none)
+    nn.fully_connect
+    nn.clip_threshold = 0.5
+    nn.w_gradient << 1000.0
+    nn.b_gradient << 1000.0
+    nn.b_gradient << 1000.0
+    nn.update_weights(:sgdm)
+    nn.update_biases(:sgdm)
+    nn.all_synapses.first.gradient.should eq(0.5)
+    nn.all_neurons.each { |n| n.gradient.should eq(0.5) }
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -424,7 +424,9 @@ module SHAInet
     def update_weights(learn_type : Symbol | String, batch : Bool = false)
       @all_synapses.each_with_index do |synapse, i|
         # Get current gradient (needed for mini-batch)
-        synapse.gradient = @w_gradient.not_nil![i]
+        grad = @w_gradient.not_nil![i]
+        grad = grad.clamp(-@clip_threshold, @clip_threshold)
+        synapse.gradient = grad
 
         case learn_type.to_s
         # Update weights based on the gradients and delta rule (including momentum)
@@ -476,7 +478,9 @@ module SHAInet
     def update_biases(learn_type : Symbol | String, batch : Bool = false)
       @all_neurons.each_with_index do |neuron, i|
         # Get current gradient (needed for mini-batch)
-        neuron.gradient = @b_gradient.not_nil![i]
+        grad = @b_gradient.not_nil![i]
+        grad = grad.clamp(-@clip_threshold, @clip_threshold)
+        neuron.gradient = grad
 
         case learn_type.to_s
         # Update biases based on the gradients and delta rule (including momentum)

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -38,6 +38,7 @@ module SHAInet
     # Parameters for Adam
     property alpha : Float64
     getter beta1 : Float64, beta2 : Float64, epsilon : Float64, time_step : Int32
+    property clip_threshold : Float64
 
     # First creates an empty shell of the entire network
     def initialize
@@ -70,6 +71,7 @@ module SHAInet
       @epsilon = 10e-8_f64 # For Adam , prevents exploding gradients (not recommended to change value)
       @time_step = 0_i32   # For Adam
       @transformer_error = SimpleMatrix.zeros(1, 1)
+      @clip_threshold = Float64::INFINITY
     end
 
     # Create and populate a layer with neurons


### PR DESCRIPTION
## Summary
- add `clip_threshold` property on `Network` with default of `Float64::INFINITY`
- clamp gradients in `update_weights` and `update_biases`
- document the option in the README
- test clipping behaviour with a new spec

## Testing
- `crystal spec --fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_685aabc0dbc48331b5a8dfcf8933ac0a