### PR TITLE
Add TorchScript transformer import

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,9 @@ crystal run examples/transformer_pe.cr
 
 ### Loading a PyTorch model
 
-SHAInet can import simple sequential models exported from PyTorch as TorchScript.
-First export your model from Python:
+SHAInet can import simple sequential models or a tiny Transformer
+exported from PyTorch as TorchScript. First export your model from
+Python:
 
 ```python
 import torch
@@ -403,6 +404,21 @@ Then load the file in Crystal:
 net = SHAInet::Network.new
 net.load_from_pt("model.pt")
 output = net.run([1.0, 2.0])
+```
+
+To create a tiny Transformer model for import you can use the helper
+script:
+
+```bash
+python3 scripts/build_transformer_model.py transformer.pt
+```
+
+Then load it the same way (input is a token id):
+
+```crystal
+net = SHAInet::Network.new
+net.load_from_pt("transformer.pt")
+out = net.run([1])
 ```
 
 ### Possible Future Features

--- a/scripts/build_transformer_model.py
+++ b/scripts/build_transformer_model.py
@@ -1,0 +1,68 @@
+import sys
+import math
+import warnings
+try:
+    import torch
+except Exception as e:
+    sys.stderr.write("PyTorch not installed: %s\n" % e)
+    sys.exit(1)
+
+warnings.filterwarnings("ignore")
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: build_transformer_model.py <output.pt>\n")
+    sys.exit(1)
+
+class SHAIMultiheadAttention(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.w_q = torch.nn.Linear(dim, dim, bias=False)
+        self.w_k = torch.nn.Linear(dim, dim, bias=False)
+        self.w_v = torch.nn.Linear(dim, dim, bias=False)
+        self.w_o = torch.nn.Linear(dim, dim, bias=False)
+    def forward(self, x):
+        q = self.w_q(x)
+        k = self.w_k(x)
+        v = self.w_v(x)
+        scores = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(x.size(-1))
+        attn = torch.softmax(scores, dim=-1)
+        out = torch.matmul(attn, v)
+        return self.w_o(out)
+
+class SHAIPositionWiseFF(torch.nn.Module):
+    def __init__(self, dim, hidden):
+        super().__init__()
+        self.w1 = torch.nn.Linear(dim, hidden)
+        self.w2 = torch.nn.Linear(hidden, dim)
+    def forward(self, x):
+        return self.w2(torch.relu(self.w1(x)))
+
+class SHAISimpleLayer(torch.nn.Module):
+    def __init__(self, dim, hidden):
+        super().__init__()
+        self.mha = SHAIMultiheadAttention(dim)
+        self.ffn = SHAIPositionWiseFF(dim, hidden)
+        self.norm1 = torch.nn.LayerNorm(dim)
+        self.norm2 = torch.nn.LayerNorm(dim)
+    def forward(self, x):
+        attn = self.mha(x)
+        n1 = self.norm1(attn)
+        ff = self.ffn(n1)
+        return self.norm2(ff)
+
+class TinyTransformer(torch.nn.Module):
+    def __init__(self, vocab=4, dim=2, hidden=8, out_dim=2):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(vocab, dim)
+        self.layer = SHAISimpleLayer(dim, hidden)
+        self.out = torch.nn.Linear(dim, out_dim)
+    def forward(self, x):
+        emb = self.embedding(x)
+        z = self.layer(emb)
+        return self.out(z)
+
+torch.manual_seed(0)
+model = TinyTransformer()
+example = torch.randint(0, 4, (1, 1))
+traced = torch.jit.trace(model, example)
+traced.save(sys.argv[1])

--- a/spec/pytorch_transformer_loader_spec.cr
+++ b/spec/pytorch_transformer_loader_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+describe "load_from_pt for transformer" do
+  it "loads a minimal transformer" do
+    model_path = "spec/tmp_transformer.pt"
+    system("python3", ["scripts/build_transformer_model.py", model_path])
+
+    net = SHAInet::Network.new
+    net.load_from_pt(model_path)
+    out = net.run([1])
+    out.size.should eq(2)
+    File.delete(model_path)
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -23,7 +23,12 @@ module SHAInet
       if @hidden_layers.any? &.is_a?(TransformerLayer)
         matrix = SimpleMatrix.from_a([input.map(&.to_f64)])
         @hidden_layers.each do |l|
-          if l.is_a?(TransformerLayer)
+          case l
+          when EmbeddingLayer
+            token = input.first.to_i
+            vec = l.as(EmbeddingLayer).lookup(token)
+            matrix = SimpleMatrix.from_a([vec])
+          when TransformerLayer
             matrix = l.as(TransformerLayer).forward(matrix)
           end
         end

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -369,33 +369,89 @@ module SHAInet
     end
 
     # Load a network from a TorchScript file exported via PyTorch.
-    # Only sequential Linear layers are currently supported.
+    # Supports simple sequential Linear models as well as a minimal
+    # Transformer consisting of an embedding layer followed by a
+    # single TransformerLayer and a final Linear output layer.
     def load_from_pt(file_path : String)
       data = PyTorchImport.load(file_path)
       layers = data["layers"].as_a
 
-      input_size = layers.first["weight"].as_a.first.as_a.size
-      add_layer(:input, input_size)
+      lookup = Hash(String, JSON::Any).new
+      layers.each { |l| lookup[l["name"].as_s] = l }
 
-      layers.each_with_index do |l, idx|
-        out_size = l["weight"].as_a.size
-        if idx == layers.size - 1
-          add_layer(:output, out_size, activation_function: SHAInet.identity)
-        else
-          add_layer(:hidden, out_size, activation_function: SHAInet.relu)
+      if lookup.has_key?("embedding")
+        # Transformer style model
+        emb_w = lookup["embedding"]["weight"].as_a
+        d_model = emb_w.first.as_a.size
+        out_size = lookup["out"]? ? lookup["out"]["weight"].as_a.size : d_model
+
+        add_layer(:input, 1)
+        add_layer(:embedding, d_model)
+        add_layer(:transformer, d_model)
+        add_layer(:output, out_size, activation_function: SHAInet.identity)
+        fully_connect
+
+        emb_layer = @hidden_layers.find(&.is_a?(EmbeddingLayer)).as(EmbeddingLayer)
+        emb_w.each_with_index do |row, idx|
+          emb_layer.embeddings[idx] = row.as_a.map(&.as_f)
         end
-      end
-      fully_connect
 
-      target_layers = @hidden_layers + @output_layers
-      layers.each_with_index do |l, idx|
-        weights = l["weight"].as_a
-        bias = l["bias"].as_a
-        target = target_layers[idx]
-        target.neurons.each_with_index do |neuron, i|
-          neuron.bias = bias[i].as_f
-          neuron.synapses_in.each_with_index do |syn, j|
-            syn.weight = weights[i].as_a[j].as_f
+        t_layer = @transformer_layers.first
+        mha = t_layer.mha
+        mha.w_q = SimpleMatrix.from_a(lookup["layer.mha.w_q"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+        mha.w_k = SimpleMatrix.from_a(lookup["layer.mha.w_k"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+        mha.w_v = SimpleMatrix.from_a(lookup["layer.mha.w_v"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+        mha.w_o = SimpleMatrix.from_a(lookup["layer.mha.w_o"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+
+        ffn = t_layer.ffn
+        ffn.w1 = SimpleMatrix.from_a(lookup["layer.ffn.w1"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+        ffn.b1 = SimpleMatrix.from_a([lookup["layer.ffn.w1"]["bias"].as_a.map(&.as_f)])
+        ffn.w2 = SimpleMatrix.from_a(lookup["layer.ffn.w2"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+        ffn.b2 = SimpleMatrix.from_a([lookup["layer.ffn.w2"]["bias"].as_a.map(&.as_f)])
+
+        n1 = t_layer.norm1
+        n1.gamma = SimpleMatrix.from_a([lookup["layer.norm1"]["weight"].as_a.map(&.as_f)])
+        n1.beta = SimpleMatrix.from_a([lookup["layer.norm1"]["bias"].as_a.map(&.as_f)])
+        n2 = t_layer.norm2
+        n2.gamma = SimpleMatrix.from_a([lookup["layer.norm2"]["weight"].as_a.map(&.as_f)])
+        n2.beta = SimpleMatrix.from_a([lookup["layer.norm2"]["bias"].as_a.map(&.as_f)])
+
+        if out = lookup["out"]?
+          weights = out["weight"].as_a
+          bias = out["bias"].as_a
+          target = @output_layers.first
+          target.neurons.each_with_index do |neuron, i|
+            neuron.bias = bias[i].as_f
+            neuron.synapses_in.each_with_index do |syn, j|
+              syn.weight = weights[i].as_a[j].as_f
+            end
+          end
+        end
+      else
+        # Sequential linear model
+        input_size = layers.first["weight"].as_a.first.as_a.size
+        add_layer(:input, input_size)
+
+        layers.each_with_index do |l, idx|
+          out_size = l["weight"].as_a.size
+          if idx == layers.size - 1
+            add_layer(:output, out_size, activation_function: SHAInet.identity)
+          else
+            add_layer(:hidden, out_size, activation_function: SHAInet.relu)
+          end
+        end
+        fully_connect
+
+        target_layers = @hidden_layers + @output_layers
+        layers.each_with_index do |l, idx|
+          weights = l["weight"].as_a
+          bias = l["bias"].as_a
+          target = target_layers[idx]
+          target.neurons.each_with_index do |neuron, i|
+            neuron.bias = bias[i].as_f
+            neuron.synapses_in.each_with_index do |syn, j|
+              syn.weight = weights[i].as_a[j].as_f
+            end
           end
         end
       end

--- a/src/shainet/transformer/ext.cr
+++ b/src/shainet/transformer/ext.cr
@@ -1,0 +1,20 @@
+module SHAInet
+  class MultiHeadAttention
+    def w_q=(m : SimpleMatrix); @w_q = m; end
+    def w_k=(m : SimpleMatrix); @w_k = m; end
+    def w_v=(m : SimpleMatrix); @w_v = m; end
+    def w_o=(m : SimpleMatrix); @w_o = m; end
+  end
+
+  class PositionWiseFF
+    def w1=(m : SimpleMatrix); @w1 = m; end
+    def b1=(m : SimpleMatrix); @b1 = m; end
+    def w2=(m : SimpleMatrix); @w2 = m; end
+    def b2=(m : SimpleMatrix); @b2 = m; end
+  end
+
+  class LayerNorm
+    def gamma=(m : SimpleMatrix); @gamma = m; end
+    def beta=(m : SimpleMatrix); @beta = m; end
+  end
+end


### PR DESCRIPTION
## Summary
- handle embeddings and transformer weights in `load_from_pt`
- add python helper to export a tiny Transformer
- support setting transformer parameters
- allow running transformers with embedding layers
- add transformer loader spec
- document importing transformers from PyTorch

## Testing
- `crystal spec spec/pytorch_transformer_loader_spec.cr`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685ab11d40c483319c722f6428057e01