### PR TITLE
Fix examples so they compile

### DIFF
--- a/examples/llm_sample.cr
+++ b/examples/llm_sample.cr
@@ -21,7 +21,7 @@ net = SHAInet::Network.new
 net.add_layer(:input, 1, :memory, SHAInet.none)
 net.add_layer(:embedding, 8, :memory, SHAInet.none)
 net.add_layer(:lstm, 16)
-net.add_layer(:output, token_count, :memory, SHAInet.softmax)
+net.add_layer(:output, token_count, :memory, SHAInet.sigmoid)
 net.fully_connect
 
 # Helper to create one-hot vectors
@@ -39,8 +39,11 @@ training = [] of Tuple(Array(Array(Float64)), Array(Float64))
   training << {input, expected}
 end
 
+# Convert tuples to arrays for training
+train_data = training.map { |seq, target| [seq, target] }
+
 net.learning_rate = 0.1
-net.train(data: training,
+net.train(data: train_data,
   training_type: :sgdm,
   cost_function: :c_ent,
   epochs: 200,

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -21,7 +21,7 @@ net = SHAInet::Network.new
 net.add_layer(:input, 1, :memory, SHAInet.none)
 net.add_layer(:embedding, 8, :memory, SHAInet.none)
 net.add_layer(:transformer, 8)
-net.add_layer(:output, token_count, :memory, SHAInet.softmax)
+net.add_layer(:output, token_count, :memory, SHAInet.sigmoid)
 net.fully_connect
 
 # Helper to create one-hot vectors
@@ -39,8 +39,11 @@ training = [] of Tuple(Array(Array(Float64)), Array(Float64))
   training << {input, expected}
 end
 
+# Convert tuples to arrays for training
+train_data = training.map { |seq, target| [seq, target] }
+
 net.learning_rate = 0.1
-net.train(data: training,
+net.train(data: train_data,
   training_type: :sgdm,
   cost_function: :c_ent,
   epochs: 200,


### PR DESCRIPTION
## Summary
- fix activation type for output layers
- convert example training data to array form
- ensure all examples compile with `crystal build`

## Testing
- `crystal build examples/babylm_transformer.cr`
- `crystal build examples/llm_sample.cr`
- `crystal build examples/transformer_lm.cr`
- `crystal build examples/transformer_pe.cr`


------
https://chatgpt.com/codex/tasks/task_e_685ae7996f9083318998c2c0a444f0b7