### PR TITLE
Enable CUDA token matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ Example use of an embedding layer followed by an LSTM:
 ```crystal
 tokenizer = SHAInet::Tokenizer.new
 ids = tokenizer.encode("hello world hello")
+# Convert directly to a matrix, using the GPU when available
+ids_matrix = tokenizer.encode_matrix("hello world hello")
 
 net = SHAInet::Network.new
 net.add_layer(:input, 1)

--- a/spec/tokenizer_spec.cr
+++ b/spec/tokenizer_spec.cr
@@ -9,4 +9,17 @@ describe SHAInet::Tokenizer do
     ids.should eq([0, 1])
     tokenizer.decode(ids).should eq(["hello", "world"])
   end
+
+  it "encodes to a matrix using CUDA when available" do
+    tokenizer = SHAInet::Tokenizer.new
+    tokenizer.build("hello world")
+    matrix = tokenizer.encode_matrix("hello world")
+    if SHAInet::CUDA.available?
+      matrix.should be_a(SHAInet::CudaMatrix)
+    else
+      matrix.should be_a(SHAInet::SimpleMatrix)
+    end
+    matrix[0, 0].should eq(0.0)
+    matrix[0, 1].should eq(1.0)
+  end
 end

--- a/src/shainet/text/tokenizer.cr
+++ b/src/shainet/text/tokenizer.cr
@@ -1,3 +1,7 @@
+require "../cuda"
+require "../math/simple_matrix"
+require "../math/cuda_matrix"
+
 module SHAInet
   # Very small tokenizer used for toy examples. It builds a vocabulary of words
   # from given text and encodes/decodes sentences to arrays of token IDs.
@@ -24,6 +28,16 @@ module SHAInet
       text.split(/\s+/).map do |token|
         add_token(token)
       end
+    end
+
+    # Encode a string into a matrix of token IDs using GPU matrices when CUDA
+    # is available. The returned matrix has one row with each column containing
+    # the token id as a float. This can be used directly as network input when
+    # training language models.
+    def encode_matrix(text : String)
+      ids = encode(text)
+      mat_klass = CUDA.available? ? CudaMatrix : SimpleMatrix
+      mat_klass.from_a([ids.map(&.to_f64)])
     end
 
     # Convert an array of token IDs back to their corresponding words. Unknown


### PR DESCRIPTION
## Summary
- add new `encode_matrix` method in `Tokenizer` producing `CudaMatrix` when CUDA is available
- document CUDA token encoding in README
- test GPU aware encoding

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685aed8581d8833191b185753e74baa2