### PR TITLE
Add token batch streaming with shuffling

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,28 @@ An additional example `examples/transformer_pe.cr` demonstrates using a
 crystal run examples/transformer_pe.cr
 ```
 
+#### Streaming token batches
+`StreamingData` can also stream batches of token ids produced by
+`BPETokenizer`. Each line in the data file should contain a JSON array
+describing the tokenized input sequence and expected token:
+
+```crystal
+tokenizer = SHAInet::BPETokenizer.new
+tokenizer.train("hello world hello world", 30)
+ids = tokenizer.encode("hello world hello world")
+
+File.open("tokens.txt", "w") do |f|
+  (0...ids.size - 1).each do |i|
+    pair = [[[ids[i]]], [ids[i + 1]]]
+    f.puts pair.to_json
+  end
+end
+
+stream = SHAInet::StreamingData.new("tokens.txt", shuffle: true)
+batch = stream.next_batch(2)
+stream.rewind # start a new shuffled epoch
+```
+
 ### Loading a PyTorch model
 
 SHAInet can import simple sequential models or a tiny Transformer

--- a/spec/streaming_data_spec.cr
+++ b/spec/streaming_data_spec.cr
@@ -31,4 +31,23 @@ describe SHAInet::StreamingData do
 
     (net.run(input: [0, 0], stealth: true).first < 0.2).should be_true
   end
+
+  it "reads tokenized data and reshuffles each epoch" do
+    Random::DEFAULT.new_seed(42_u64, 13_u64)
+    File.open("/tmp/stream_tok.txt", "w") do |f|
+      f.puts "[[[1]], [2]]"
+      f.puts "[[[3]], [4]]"
+      f.puts "[[[5]], [6]]"
+    end
+
+    data = SHAInet::StreamingData.new("/tmp/stream_tok.txt", shuffle: true)
+
+    first_epoch = data.next_batch(3)
+    first_epoch.size.should eq(3)
+    first_epoch.first[0].is_a?(Array).should be_true
+
+    data.rewind
+    second_epoch = data.next_batch(3)
+    second_epoch.size.should eq(3)
+  end
 end

--- a/src/shainet/data/streaming_data.cr
+++ b/src/shainet/data/streaming_data.cr
@@ -2,29 +2,55 @@ module SHAInet
   # StreamingData reads training data lazily from a text file. Each line should
   # contain a JSON array: [[inputs...], [outputs...]]
   class StreamingData
+    alias Datum = Array(Float64) | Array(Array(Float64))
     @path : String
-    @file : File
+    @lines : Array(String)
+    @index : Int32 = 0
+    @shuffle : Bool
 
-    def initialize(@path : String)
-      @file = File.new(@path, "r")
+    # Reads data from `path`. When `shuffle` is true the file is read into
+    # memory and shuffled at the beginning of every epoch.
+    def initialize(@path : String, @shuffle : Bool = false)
+      @lines = File.read_lines(@path)
+      shuffle! if @shuffle
     end
 
+    # Returns the next `batch_size` examples. Each line may contain either a
+    # flat array of numbers or nested arrays of token ids. All numbers are
+    # converted to `Float64`.
     def next_batch(batch_size : Int32)
-      batch = [] of Array(Array(Float64))
+      batch = [] of Array(Datum)
       batch_size.times do
-        line = @file.gets
-        break unless line
-        pair = JSON.parse(line).as_a
-        input = pair[0].as_a.map { |x| x.as_f }
-        output = pair[1].as_a.map { |x| x.as_f }
+        break if @index >= @lines.size
+        pair = JSON.parse(@lines[@index]).as_a
+        @index += 1
+        input = parse_array(pair[0])
+        output = parse_array(pair[1])
         batch << [input, output]
       end
       batch
     end
 
+    # Resets the data pointer for a new epoch and reshuffles if enabled.
     def rewind
-      @file.close
-      @file = File.new(@path, "r")
+      @index = 0
+      shuffle! if @shuffle
+    end
+
+    private def shuffle!
+      @lines.shuffle!
+    end
+
+    # Parses a JSON array and converts all numeric values to Float64. Supports
+    # both 1‑D and 2‑D arrays which is useful for tokenized inputs.
+    private def parse_array(json_any : JSON::Any) : Datum
+      arr = json_any.as_a
+      return [] of Float64 if arr.empty?
+      if arr.first.raw.is_a?(Array)
+        Array(Array(Float64)).from_json(json_any.to_json)
+      else
+        Array(Float64).from_json(json_any.to_json)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- extend `StreamingData` to handle tokenized batches
- support shuffling and epoch resets for streaming data
- document token streaming usage
- test token streaming logic

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_685aed6b1c8483318440455b7f0a4658