### PR TITLE
Enable optional CUDA path for BPETokenizer

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -37,6 +37,20 @@ module SHAInet
       m
     end
 
+    # Return the transposed matrix. When CUDA is available the returned
+    # instance keeps the device buffer in sync so that further GPU
+    # operations can be used without additional copies.
+    def transpose
+      result = CudaMatrix.new(@cols, @rows)
+      @rows.times do |i|
+        @cols.times do |j|
+          result[j, i] = self[i, j]
+        end
+      end
+      result.sync_to_device!
+      result
+    end
+
     def sync_to_device!
       return unless dptr = @device_ptr
       return if dptr.null?


### PR DESCRIPTION
## Summary
- add transpose support to CudaMatrix
- introduce optional CUDA-based training routine for BPETokenizer

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_685af2e3951c833185614615499ec3db