### PR TITLE
Fix multi IO run

### DIFF
--- a/spec/multi_io_spec.cr
+++ b/spec/multi_io_spec.cr
@@ -1,0 +1,22 @@
+require "./spec_helper"
+
+describe "multi input/output" do
+  it "handles multiple input and output layers" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:hidden, 2, :memory, SHAInet.sigmoid)
+    net.add_layer(:output, 1, :memory, SHAInet.none)
+    net.fully_connect
+
+    # add a second output layer manually
+    extra = SHAInet::Layer.new("memory", 1)
+    net.output_layers << extra
+    net.all_neurons.concat(extra.neurons)
+    net.connect_ltl(net.hidden_layers.last, extra, :full)
+
+    net.randomize_all_weights
+    result = net.run([0.1, 0.2])
+    result.size.should eq(2)
+  end
+end


### PR DESCRIPTION
## Summary
- support assigning inputs across multiple input layers
- collect activations from all output layers
- implement same logic for experimental runner
- add spec for multi-input/multi-output networks

## Testing
- `crystal spec --order random spec/multi_io_spec.cr`
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_685af3876f388331a00f8d7d247a4325