### PR TITLE
Optimize BPE tokenizer training

### DIFF
--- a/src/shainet/text/bpe_tokenizer.cr
+++ b/src/shainet/text/bpe_tokenizer.cr
@@ -10,19 +10,28 @@ module SHAInet
     getter vocab : Hash(String, Int32)
     getter inv_vocab : Array(String)
     getter merges : Array(Tuple(String, String))
+    getter merges_map : Hash(Tuple(String, String), String)
 
     def initialize
       @vocab = Hash(String, Int32).new
       @inv_vocab = [] of String
       @merges = [] of Tuple(String, String)
+      @merges_map = Hash(Tuple(String, String), String).new
     end
 
     # Train the tokenizer vocabulary from the given text using the
     # byte-pair encoding algorithm. `vocab_size` determines how many
     # unique tokens will be created at most.
     def train(text : String, vocab_size : Int32)
-      corpus = text.split(/\s+/).map { |w| w.chars.map(&.to_s) + ["</w>"] }
-      corpus.each do |tokens|
+      word_freqs = Hash(String, Int32).new(0)
+      text.split(/\s+/).each { |w| word_freqs[w] += 1 }
+
+      corpus = [] of Array(String)
+      freqs = [] of Int32
+      word_freqs.each do |word, count|
+        tokens = word.chars.map(&.to_s) + ["</w>"]
+        corpus << tokens
+        freqs << count
         tokens.each { |t| add_token(t) }
       end
 
@@ -30,20 +39,34 @@ module SHAInet
         Log.debug { "Merges done: #{@merges.size}, vocabulary size: #{@vocab.size}" }
         Log.debug { "Progress: #{(@vocab.size.to_f / vocab_size * 100.0).round(2)}%" }
         pair_counts = Hash(Tuple(Int32, Int32), Int32).new(0)
-        corpus.each do |tokens|
+        corpus.each_with_index do |tokens, idx|
+          freq = freqs[idx]
           (0...(tokens.size - 1)).each do |i|
-            id1 = @vocab[tokens[i]]
-            id2 = @vocab[tokens[i + 1]]
-            pair_counts[{id1, id2}] += 1
+            t1 = tokens[i]
+            t2 = tokens[i + 1]
+            id1 = @vocab[t1]?
+            id2 = @vocab[t2]?
+            if id1 && id2
+              pair_counts[{id1, id2}] += freq
+            end
           end
         end
         break if pair_counts.empty?
         Log.debug { "Found #{pair_counts.size} unique pairs to merge." }
-        best_pair_ids, _ = pair_counts.max_by { |_, count| count }
+        heap = PairHeap.new
+        pair_counts.each do |pair, count|
+          heap.push PairHeap::Node.new(pair, count)
+        end
+        best_node = heap.pop
+        break unless best_node
+        best_pair_ids = best_node.pair
 
         token_a = @inv_vocab[best_pair_ids[0]]
         token_b = @inv_vocab[best_pair_ids[1]]
-        new_token = token_a + token_b
+        new_token = String.build do |io|
+          io << token_a
+          io << token_b
+        end
         corpus.each do |tokens|
           i = 0
           while i < tokens.size - 1
@@ -55,7 +78,9 @@ module SHAInet
             end
           end
         end
-        @merges << {token_a, token_b}
+        pair = {token_a, token_b}
+        @merges << pair
+        @merges_map[pair] = new_token
         add_token(new_token)
       end
     end
@@ -90,10 +115,15 @@ module SHAInet
     end
 
     private def merge_tokens!(tokens : Array(String), pair : Tuple(String, String))
+      new_token = @merges_map[pair]?
+      new_token ||= String.build do |io|
+        io << pair[0]
+        io << pair[1]
+      end
       i = 0
       while i < tokens.size - 1
         if tokens[i] == pair[0] && tokens[i + 1] == pair[1]
-          tokens[i] = pair[0] + pair[1]
+          tokens[i] = new_token
           tokens.delete_at(i + 1)
         else
           i += 1
@@ -109,6 +139,63 @@ module SHAInet
         @vocab[token] = new_id
         @inv_vocab << token
         new_id
+      end
+    end
+  end
+
+  # Simple max-heap used to select the best pair during training
+  class PairHeap
+    struct Node
+      getter pair : Tuple(Int32, Int32)
+      getter count : Int32
+
+      def initialize(@pair : Tuple(Int32, Int32), @count : Int32)
+      end
+    end
+
+    def initialize
+      @data = [] of Node
+    end
+
+    def push(node : Node)
+      @data << node
+      sift_up(@data.size - 1)
+    end
+
+    def pop : Node?
+      return nil if @data.empty?
+      max = @data[0]
+      last = @data.pop
+      if !@data.empty?
+        @data[0] = last
+        sift_down(0)
+      end
+      max
+    end
+
+    private def sift_up(idx : Int32)
+      while idx > 0
+        parent = (idx - 1) // 2
+        if @data[parent].count < @data[idx].count
+          @data[parent], @data[idx] = @data[idx], @data[parent]
+          idx = parent
+        else
+          break
+        end
+      end
+    end
+
+    private def sift_down(idx : Int32)
+      size = @data.size
+      while true
+        left = idx * 2 + 1
+        right = left + 1
+        largest = idx
+        largest = left if left < size && @data[left].count > @data[largest].count
+        largest = right if right < size && @data[right].count > @data[largest].count
+        break if largest == idx
+        @data[idx], @data[largest] = @data[largest], @data[idx]
+        idx = largest
       end
     end
   end


### PR DESCRIPTION
## Summary
- cache unique word tokens with frequencies to avoid repeated preprocessing
- use a custom max heap to select the most frequent pair

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_685bd058f9b88331b5f00fe80e5a68a2