### PR TITLE
Add concurrent tokenizer using worker actors

### DIFF
--- a/spec/concurrent_tokenizer_spec.cr
+++ b/spec/concurrent_tokenizer_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+describe SHAInet::ConcurrentTokenizer(SHAInet::Tokenizer) do
+  it "encodes text concurrently" do
+    tokenizer = SHAInet::Tokenizer.new
+    tokenizer.build("hello world test concurrency")
+    concurrent = SHAInet::ConcurrentTokenizer(SHAInet::Tokenizer).new(tokenizer, 2)
+    inputs = ["hello world", "test concurrency"]
+
+    sequential = inputs.map { |txt| tokenizer.encode(txt) }
+    parallel = concurrent.encode_batch(inputs)
+    parallel.should eq(sequential)
+  end
+end

--- a/src/shainet/concurrency/concurrent_tokenizer.cr
+++ b/src/shainet/concurrency/concurrent_tokenizer.cr
@@ -1,0 +1,76 @@
+require "wait_group"
+
+module SHAInet
+  # Actor-like wrapper around a tokenizer that encodes texts in parallel.
+  #
+  # It spawns a number of worker fibers that receive tasks over a channel.
+  # When compiled with `-Dpreview_mt -Dexecution_context` the workers run on a
+  # dedicated `ExecutionContext::MultiThreaded` allowing parallel execution.
+  # Otherwise the same implementation works with Crystal's default scheduler.
+  class ConcurrentTokenizer(T)
+    private struct EncodeJob
+      getter text : String
+      getter result : Channel(Array(Int32))
+
+      def initialize(@text : String, @result : Channel(Array(Int32)))
+      end
+    end
+
+    alias Job = EncodeJob?
+
+    @jobs : Channel(Job)
+    @workers : Array(Fiber)
+    @worker_count : Int32
+
+    def initialize(@tokenizer : T, worker_count : Int32 = 4)
+      @worker_count = worker_count
+      @jobs = Channel(Job).new
+      @workers = [] of Fiber
+
+      {% if flag?(:execution_context) %}
+        context = Fiber::ExecutionContext::MultiThreaded.new("tokenizer-workers", worker_count)
+        worker_count.times do
+          @workers << spawn(context: context) { worker_loop }
+        end
+      {% else %}
+        worker_count.times do
+          @workers << spawn { worker_loop }
+        end
+      {% end %}
+    end
+
+    # Encode a single text by sending it to a worker and waiting on the result.
+    def encode(text : String) : Array(Int32)
+      result = Channel(Array(Int32)).new
+      @jobs.send EncodeJob.new(text, result)
+      result.receive
+    end
+
+    # Encode multiple texts concurrently using `WaitGroup`.
+    def encode_batch(texts : Array(String)) : Array(Array(Int32))
+      results = Array(Array(Int32) | Nil).new(texts.size) { nil }
+
+      WaitGroup.wait do |wg|
+        texts.each_with_index do |text, idx|
+          wg.spawn do
+            results[idx] = encode(text)
+          end
+        end
+      end
+
+      results.compact
+    end
+
+    # Stop all workers. Pending jobs will be processed first.
+    def shutdown
+      @worker_count.times { @jobs.send(nil) }
+    end
+
+    private def worker_loop
+      while job = @jobs.receive?
+        result = @tokenizer.encode(job.text)
+        job.result.send(result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `ConcurrentTokenizer` to run tokenization jobs on a pool of worker fibers
- allow batch encoding with `WaitGroup`
- test concurrent tokenizer

## Testing
- `crystal spec --order random spec/concurrent_tokenizer_spec.cr`
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_685bf78b8e548331be8cd23edf412f6c