### PR TITLE
Expand CUDA support in transformer layers

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -22,6 +22,14 @@ module SHAInet
                          alpha : Pointer(Float64), a : Pointer(Float64), lda : Int32,
                          b : Pointer(Float64), ldb : Int32,
                          beta : Pointer(Float64), c : Pointer(Float64), ldc : Int32) : Int32
+      fun cublasDgeam(handle : Handle,
+                      transa : Int32, transb : Int32,
+                      m : Int32, n : Int32,
+                      alpha : Pointer(Float64), a : Pointer(Float64), lda : Int32,
+                      beta  : Pointer(Float64), b : Pointer(Float64), ldb : Int32,
+                      c : Pointer(Float64), ldc : Int32) : Int32
+      fun cublasDscal_v2(handle : Handle, n : Int32,
+                         alpha : Pointer(Float64), x : Pointer(Float64), incx : Int32) : Int32
     end
 
     enum MemcpyKind
@@ -103,6 +111,20 @@ module SHAInet
         pointerof(alpha), a, m,
         b, k,
         pointerof(beta), c, m)
+    end
+
+    def geam(handle : LibCUBLAS::Handle, a : Pointer(Float64), b : Pointer(Float64), c : Pointer(Float64),
+             m : Int32, n : Int32, alpha : Float64, beta : Float64)
+      LibCUBLAS.cublasDgeam(handle,
+        Operation::N.value, Operation::N.value,
+        m, n,
+        pointerof(alpha), a, m,
+        pointerof(beta), b, m,
+        c, m)
+    end
+
+    def scal(handle : LibCUBLAS::Handle, x : Pointer(Float64), n : Int32, alpha : Float64)
+      LibCUBLAS.cublasDscal_v2(handle, n, pointerof(alpha), x, 1)
     end
   end
 end

--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -19,16 +19,17 @@ module SHAInet
     property g_b2 : SimpleMatrix
 
     def initialize(d_model : Int32, hidden_dim : Int32)
-      @w1 = SimpleMatrix.new(d_model, hidden_dim).random_fill!
-      @b1 = SimpleMatrix.new(1, hidden_dim).random_fill!
-      @w2 = SimpleMatrix.new(hidden_dim, d_model).random_fill!
-      @b2 = SimpleMatrix.new(1, d_model).random_fill!
-      @g_w1 = SimpleMatrix.zeros(d_model, hidden_dim)
-      @g_w2 = SimpleMatrix.zeros(hidden_dim, d_model)
-      @g_b1 = SimpleMatrix.zeros(1, hidden_dim)
-      @g_b2 = SimpleMatrix.zeros(1, d_model)
-      @h = SimpleMatrix.zeros(1, 1)
-      @out = SimpleMatrix.zeros(1, 1)
+      mat_klass = CUDA.available? ? CudaMatrix : SimpleMatrix
+      @w1 = mat_klass.new(d_model, hidden_dim).random_fill!
+      @b1 = mat_klass.new(1, hidden_dim).random_fill!
+      @w2 = mat_klass.new(hidden_dim, d_model).random_fill!
+      @b2 = mat_klass.new(1, d_model).random_fill!
+      @g_w1 = mat_klass.zeros(d_model, hidden_dim)
+      @g_w2 = mat_klass.zeros(hidden_dim, d_model)
+      @g_b1 = mat_klass.zeros(1, hidden_dim)
+      @g_b2 = mat_klass.zeros(1, d_model)
+      @h = mat_klass.zeros(1, 1)
+      @out = mat_klass.zeros(1, 1)
     end
 
     def forward(x : SimpleMatrix)
@@ -52,7 +53,8 @@ module SHAInet
     def backward(d_out : SimpleMatrix)
       dh = d_out * @w2.transpose
       @g_w2 = @g_w2 + (@h.transpose * d_out)
-      db2 = SimpleMatrix.zeros(1, d_out.cols)
+      mat_klass = @w1.class
+      db2 = mat_klass.zeros(1, d_out.cols)
       d_out.rows.times do |i|
         d_out.cols.times do |j|
           db2[0, j] += d_out[i, j]
@@ -61,7 +63,7 @@ module SHAInet
       @g_b2 = @g_b2 + db2
       drelu = relu_grad(@h, dh)
       @g_w1 = @g_w1 + (@x.not_nil!.transpose * drelu)
-      db1 = SimpleMatrix.zeros(1, drelu.cols)
+      db1 = mat_klass.zeros(1, drelu.cols)
       drelu.rows.times do |i|
         drelu.cols.times do |j|
           db1[0, j] += drelu[i, j]
@@ -72,22 +74,24 @@ module SHAInet
       d_input
     end
 
-    def apply_gradients(lr : Float64)
+   def apply_gradients(lr : Float64)
+      mat_klass = @w1.class
       @w1 = @w1 - @g_w1 * lr
       @b1 = @b1 - @g_b1 * lr
       @w2 = @w2 - @g_w2 * lr
       @b2 = @b2 - @g_b2 * lr
-      @g_w1 = SimpleMatrix.zeros(@w1.rows, @w1.cols)
-      @g_w2 = SimpleMatrix.zeros(@w2.rows, @w2.cols)
-      @g_b1 = SimpleMatrix.zeros(@b1.rows, @b1.cols)
-      @g_b2 = SimpleMatrix.zeros(@b2.rows, @b2.cols)
+      @g_w1 = mat_klass.zeros(@w1.rows, @w1.cols)
+      @g_w2 = mat_klass.zeros(@w2.rows, @w2.cols)
+      @g_b1 = mat_klass.zeros(@b1.rows, @b1.cols)
+      @g_b2 = mat_klass.zeros(@b2.rows, @b2.cols)
     end
 
-    def zero_gradients
-      @g_w1 = SimpleMatrix.zeros(@w1.rows, @w1.cols)
-      @g_w2 = SimpleMatrix.zeros(@w2.rows, @w2.cols)
-      @g_b1 = SimpleMatrix.zeros(@b1.rows, @b1.cols)
-      @g_b2 = SimpleMatrix.zeros(@b2.rows, @b2.cols)
+   def zero_gradients
+      mat_klass = @w1.class
+      @g_w1 = mat_klass.zeros(@w1.rows, @w1.cols)
+      @g_w2 = mat_klass.zeros(@w2.rows, @w2.cols)
+      @g_b1 = mat_klass.zeros(@b1.rows, @b1.cols)
+      @g_b2 = mat_klass.zeros(@b2.rows, @b2.cols)
     end
 
     private def relu!(m : SimpleMatrix)


### PR DESCRIPTION
## Summary
- add additional cuBLAS bindings for matrix ops
- extend `CudaMatrix` with GPU-aware math helpers
- allocate transformer matrices on GPU when available
- sync CUDA-aware values in layer norm and feed-forward layers

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685c0658630c8331a8d0950614c209a7