### PR TITLE
Add HuggingFace GPT weight import

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,17 @@ net.load_from_pt("transformer.pt")
 out = net.run([1])
 ```
 
+### Loading a HuggingFace GPT model
+
+Weights from models like GPT-2 published on HuggingFace can be loaded
+directly from the `pytorch_model.bin` file. The conversion happens
+automatically using `scripts/pt_to_json.py`.
+
+```crystal
+net = SHAInet::Network.new
+net.load_from_pt("pytorch_model.bin")
+```
+
 ### Possible Future Features
   - [x] RNN (recurant neural network)
   - [x] LSTM (long-short term memory)

--- a/examples/hf_gpt_import.cr
+++ b/examples/hf_gpt_import.cr
@@ -1,0 +1,14 @@
+require "../src/shainet"
+
+# Example of loading HuggingFace GPT weights.
+# Provide the path to `pytorch_model.bin` as the first argument.
+
+unless ARGV.size > 0
+  puts "usage: crystal examples/hf_gpt_import.cr <pytorch_model.bin>"
+  exit
+end
+
+net = SHAInet::Network.new
+net.load_from_pt(ARGV[0])
+
+puts "Loaded #{net.transformer_layers.size} transformer blocks"

--- a/scripts/hf_gpt_to_json.py
+++ b/scripts/hf_gpt_to_json.py
@@ -1,0 +1,71 @@
+import json
+import sys
+import warnings
+
+try:
+    import torch
+except Exception as e:
+    sys.stderr.write("PyTorch not installed: %s\n" % e)
+    sys.exit(1)
+
+warnings.filterwarnings("ignore")
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: hf_gpt_to_json.py <pytorch_model.bin>\n")
+    sys.exit(1)
+
+state = torch.load(sys.argv[1], map_location="cpu")
+
+layers = []
+blocks = []
+
+# Embedding and optional tied output weights
+if "transformer.wte.weight" in state:
+    emb = state["transformer.wte.weight"].cpu().tolist()
+    layers.append({"name": "embedding", "weight": emb, "bias": []})
+if "lm_head.weight" in state:
+    out_w = state["lm_head.weight"].cpu().tolist()
+    out_b = state.get("lm_head.bias")
+    out_bias = out_b.cpu().tolist() if out_b is not None else []
+    layers.append({"name": "out", "weight": out_w, "bias": out_bias})
+
+index = 0
+while True:
+    prefix = f"transformer.h.{index}"
+    attn_w = state.get(prefix + ".attn.c_attn.weight")
+    if attn_w is None:
+        break
+    blocks.append(f"layer{index}")
+    attn_b = state[prefix + ".attn.c_attn.bias"]
+    proj_w = state[prefix + ".attn.c_proj.weight"].t()
+    proj_b = state[prefix + ".attn.c_proj.bias"]
+    hidden = attn_b.shape[0] // 3
+    wqkv = attn_w.t()
+    w_q = wqkv[:hidden].cpu().tolist()
+    w_k = wqkv[hidden:2*hidden].cpu().tolist()
+    w_v = wqkv[2*hidden:].cpu().tolist()
+    b_q = attn_b[:hidden].cpu().tolist()
+    b_k = attn_b[hidden:2*hidden].cpu().tolist()
+    b_v = attn_b[2*hidden:].cpu().tolist()
+    layers.append({"name": f"layer{index}.mha.w_q", "weight": w_q, "bias": b_q})
+    layers.append({"name": f"layer{index}.mha.w_k", "weight": w_k, "bias": b_k})
+    layers.append({"name": f"layer{index}.mha.w_v", "weight": w_v, "bias": b_v})
+    layers.append({"name": f"layer{index}.mha.w_o", "weight": proj_w.cpu().tolist(), "bias": proj_b.cpu().tolist()})
+
+    ffn1_w = state[prefix + ".mlp.c_fc.weight"].t()
+    ffn1_b = state[prefix + ".mlp.c_fc.bias"]
+    ffn2_w = state[prefix + ".mlp.c_proj.weight"].t()
+    ffn2_b = state[prefix + ".mlp.c_proj.bias"]
+    layers.append({"name": f"layer{index}.ffn.w1", "weight": ffn1_w.cpu().tolist(), "bias": ffn1_b.cpu().tolist()})
+    layers.append({"name": f"layer{index}.ffn.w2", "weight": ffn2_w.cpu().tolist(), "bias": ffn2_b.cpu().tolist()})
+
+    ln1_w = state[prefix + ".ln_1.weight"].cpu().tolist()
+    ln1_b = state[prefix + ".ln_1.bias"].cpu().tolist()
+    ln2_w = state[prefix + ".ln_2.weight"].cpu().tolist()
+    ln2_b = state[prefix + ".ln_2.bias"].cpu().tolist()
+    layers.append({"name": f"layer{index}.norm1", "weight": ln1_w, "bias": ln1_b})
+    layers.append({"name": f"layer{index}.norm2", "weight": ln2_w, "bias": ln2_b})
+
+    index += 1
+
+print(json.dumps({"layers": layers, "blocks": blocks}))

--- a/scripts/pt_to_json.py
+++ b/scripts/pt_to_json.py
@@ -11,37 +11,116 @@ except Exception as e:
 warnings.filterwarnings("ignore")
 
 if len(sys.argv) < 2:
-    sys.stderr.write("usage: pt_to_json.py <model.pt>\n")
+    sys.stderr.write("usage: pt_to_json.py <model.pt|pytorch_model.bin>\n")
     sys.exit(1)
 
-model = torch.jit.load(sys.argv[1], map_location="cpu")
-state = model.state_dict()
 
-# Preserve parameter order from PyTorch so that repeated blocks
-# (e.g. layers within a transformer) are emitted in the same
-# order as defined in the model.
-keys = list(state.keys())
+def convert_torchscript(path):
+    model = torch.jit.load(path, map_location="cpu")
+    state = model.state_dict()
 
-layers = []
-blocks = []
-for key in keys:
-    if key.endswith(".weight"):
-        name = key[:-7]
-        weight = state[key].cpu().tolist()
-        bias = state.get(name + ".bias")
-        bias_list = bias.cpu().tolist() if bias is not None else []
-        layers.append({"name": name, "weight": weight, "bias": bias_list})
+    keys = list(state.keys())  # preserve parameter order
 
-        # Detect repeating layer groups such as layers.0 or layer1 and
-        # store them so the loader can recreate the original ordering.
-        parts = name.split(".")
-        prefix = None
-        if parts[0].startswith("layers"):
-            if len(parts) > 1:
-                prefix = parts[0] + "." + parts[1]
-        elif parts[0].startswith("layer"):
-            prefix = parts[0]
-        if prefix and prefix not in blocks:
-            blocks.append(prefix)
+    layers = []
+    blocks = []
+    for key in keys:
+        if key.endswith(".weight"):
+            name = key[:-7]
+            weight = state[key].cpu().tolist()
+            bias = state.get(name + ".bias")
+            bias_list = bias.cpu().tolist() if bias is not None else []
+            layers.append({"name": name, "weight": weight, "bias": bias_list})
 
-print(json.dumps({"layers": layers, "blocks": blocks}))
+            parts = name.split(".")
+            prefix = None
+            if parts[0].startswith("layers"):
+                if len(parts) > 1:
+                    prefix = parts[0] + "." + parts[1]
+            elif parts[0].startswith("layer"):
+                prefix = parts[0]
+            if prefix and prefix not in blocks:
+                blocks.append(prefix)
+
+    return {"layers": layers, "blocks": blocks}
+
+
+def convert_hf_gpt(path):
+    state = torch.load(path, map_location="cpu")
+
+    layers = []
+    blocks = []
+
+    if "transformer.wte.weight" in state:
+        emb = state["transformer.wte.weight"].cpu().tolist()
+        layers.append({"name": "embedding", "weight": emb, "bias": []})
+
+    if "lm_head.weight" in state:
+        out_w = state["lm_head.weight"].cpu().tolist()
+        out_b = state.get("lm_head.bias")
+        out_bias = out_b.cpu().tolist() if out_b is not None else []
+        layers.append({"name": "out", "weight": out_w, "bias": out_bias})
+
+    index = 0
+    while True:
+        prefix = f"transformer.h.{index}"
+        attn_w = state.get(prefix + ".attn.c_attn.weight")
+        if attn_w is None:
+            break
+        blocks.append(f"layer{index}")
+
+        attn_b = state[prefix + ".attn.c_attn.bias"]
+        proj_w = state[prefix + ".attn.c_proj.weight"].t()
+        proj_b = state[prefix + ".attn.c_proj.bias"]
+
+        hidden = attn_b.shape[0] // 3
+        wqkv = attn_w.t()
+        w_q = wqkv[:hidden].cpu().tolist()
+        w_k = wqkv[hidden:2 * hidden].cpu().tolist()
+        w_v = wqkv[2 * hidden :].cpu().tolist()
+        b_q = attn_b[:hidden].cpu().tolist()
+        b_k = attn_b[hidden:2 * hidden].cpu().tolist()
+        b_v = attn_b[2 * hidden :].cpu().tolist()
+
+        layers.append({"name": f"layer{index}.mha.w_q", "weight": w_q, "bias": b_q})
+        layers.append({"name": f"layer{index}.mha.w_k", "weight": w_k, "bias": b_k})
+        layers.append({"name": f"layer{index}.mha.w_v", "weight": w_v, "bias": b_v})
+        layers.append({
+            "name": f"layer{index}.mha.w_o",
+            "weight": proj_w.cpu().tolist(),
+            "bias": proj_b.cpu().tolist(),
+        })
+
+        ffn1_w = state[prefix + ".mlp.c_fc.weight"].t()
+        ffn1_b = state[prefix + ".mlp.c_fc.bias"]
+        ffn2_w = state[prefix + ".mlp.c_proj.weight"].t()
+        ffn2_b = state[prefix + ".mlp.c_proj.bias"]
+        layers.append({
+            "name": f"layer{index}.ffn.w1",
+            "weight": ffn1_w.cpu().tolist(),
+            "bias": ffn1_b.cpu().tolist(),
+        })
+        layers.append({
+            "name": f"layer{index}.ffn.w2",
+            "weight": ffn2_w.cpu().tolist(),
+            "bias": ffn2_b.cpu().tolist(),
+        })
+
+        ln1_w = state[prefix + ".ln_1.weight"].cpu().tolist()
+        ln1_b = state[prefix + ".ln_1.bias"].cpu().tolist()
+        ln2_w = state[prefix + ".ln_2.weight"].cpu().tolist()
+        ln2_b = state[prefix + ".ln_2.bias"].cpu().tolist()
+        layers.append({"name": f"layer{index}.norm1", "weight": ln1_w, "bias": ln1_b})
+        layers.append({"name": f"layer{index}.norm2", "weight": ln2_w, "bias": ln2_b})
+
+        index += 1
+
+    return {"layers": layers, "blocks": blocks}
+
+
+path = sys.argv[1]
+if path.endswith(".bin"):
+    data = convert_hf_gpt(path)
+else:
+    data = convert_torchscript(path)
+
+print(json.dumps(data))

--- a/src/shainet/pytorch_import.cr
+++ b/src/shainet/pytorch_import.cr
@@ -2,7 +2,8 @@ require "json"
 
 module SHAInet
   module PyTorchImport
-    # Returns JSON data describing sequential linear layers.
+    # Returns JSON data describing sequential linear layers or
+    # Transformer-based GPT models exported from HuggingFace.
     def self.load(file_path : String) : JSON::Any
       script = File.join(__DIR__, "../../scripts/pt_to_json.py")
       output = IO::Memory.new
@@ -12,7 +13,7 @@ module SHAInet
         output: output,
         error: Process::Redirect::Close
       )
-      raise "Failed to convert TorchScript" unless status.success?
+      raise "Failed to convert model" unless status.success?
       JSON.parse(output.to_s)
     end
   end


### PR DESCRIPTION
## Summary
- support `.bin` files from HuggingFace GPT in `pt_to_json.py`
- call python converter from `pytorch_import.cr`
- add conversion helper `hf_gpt_to_json.py`
- document how to load a HuggingFace GPT model
- add example of loading GPT weights

## Testing
- `shards install`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685c0c43330883319e2c148103431d5f