### PR TITLE
Add basic autograd tensor

### DIFF
--- a/spec/autograd_tensor_spec.cr
+++ b/spec/autograd_tensor_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+describe SHAInet::Autograd::Tensor do
+  it "computes gradients for simple operations" do
+    a = SHAInet::Autograd::Tensor.new(2.0)
+    b = SHAInet::Autograd::Tensor.new(3.0)
+    c = a * b + a
+    c.backward
+
+    a.grad.should eq(3.0 + 1.0)
+    b.grad.should eq(2.0)
+    c.grad.should eq(1.0)
+  end
+
+  it "computes gradients for matrix multiply" do
+    x = SHAInet::Autograd::Tensor.new(2.0)
+    y = SHAInet::Autograd::Tensor.new(4.0)
+    z = x.matmul(y)
+    z.backward
+
+    x.grad.should eq(4.0)
+    y.grad.should eq(2.0)
+  end
+end

--- a/src/shainet/autograd/tensor.cr
+++ b/src/shainet/autograd/tensor.cr
@@ -1,0 +1,83 @@
+module SHAInet
+  module Autograd
+    class Tensor
+      property data : Float64
+      property grad : Float64
+      property parents : Array(Tensor)
+      property backward_fn : Proc(Float64, Nil)?
+
+      def initialize(@data : Float64, @parents : Array(Tensor) = [] of Tensor, @backward_fn : Proc(Float64, Nil)? = nil)
+        @grad = 0.0
+      end
+
+      def +(other : Tensor)
+        Tensor.new(@data + other.data, [self, other], ->(g : Float64) do
+          self.grad += g
+          other.grad += g
+        end)
+      end
+
+      def +(other : Number)
+        self + Tensor.new(other.to_f)
+      end
+
+      def -(other : Tensor)
+        Tensor.new(@data - other.data, [self, other], ->(g : Float64) do
+          self.grad += g
+          other.grad -= g
+        end)
+      end
+
+      def -(other : Number)
+        self - Tensor.new(other.to_f)
+      end
+
+      def *(other : Tensor)
+        Tensor.new(@data * other.data, [self, other], ->(g : Float64) do
+          self.grad += g * other.data
+          other.grad += g * self.data
+        end)
+      end
+
+      def *(other : Number)
+        self * Tensor.new(other.to_f)
+      end
+
+      def /(other : Tensor)
+        Tensor.new(@data / other.data, [self, other], ->(g : Float64) do
+          self.grad += g / other.data
+          other.grad -= g * @data / (other.data * other.data)
+        end)
+      end
+
+      def /(other : Number)
+        self / Tensor.new(other.to_f)
+      end
+
+      def matmul(other : Tensor)
+        Tensor.new(@data * other.data, [self, other], ->(g : Float64) do
+          self.grad += g * other.data
+          other.grad += g * self.data
+        end)
+      end
+
+      def backward(initial_grad : Float64 = 1.0)
+        build_topology(self, Set(Tensor).new).reverse_each do |t|
+          if t == self
+            t.grad += initial_grad
+          end
+          t.backward_fn.try &.call(t.grad)
+        end
+      end
+
+      private def build_topology(t : Tensor, visited : Set(Tensor), topo = [] of Tensor)
+        unless visited.includes?(t)
+          visited.add(t)
+          t.parents.each { |p| build_topology(p, visited, topo) }
+          topo << t
+        end
+        topo
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- introduce `SHAInet::Autograd::Tensor` storing value, gradient and backward link
- implement differentiable operators (`+`, `-`, `*`, `/`, `matmul`) and reverse-mode autodiff
- test tensor gradients in a new spec

## Testing
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_685c0dbf73388331b2d66957ccb322da