### PR TITLE
Update BabyLM example to label-based loss

### DIFF
--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -20,7 +20,7 @@ module SHAInet
 
     LAYER_TYPES      = ["input", "hidden", "recurrent", "output"]
     CONNECTION_TYPES = ["full", "ind_to_ind", "random"]
-    COST_FUNCTIONS   = ["mse", "c_ent"] # , "exp", "hel_d", "kld", "gkld", "ita_sai_d"]
+    COST_FUNCTIONS   = ["mse", "c_ent", "c_ent_sm"] # , "exp", "hel_d", "kld", "gkld", "ita_sai_d"]
 
     # General network parameters
     getter :input_layers, :output_layers, :hidden_layers, :recurrent_layers, :lstm_layers, :all_neurons, :all_synapses


### PR DESCRIPTION
## Summary
- add `c_ent_sm` cost type for softmax cross-entropy
- implement `evaluate_label` helpers and label-mode training
- extend `verify_data` to allow single label targets
- update BabyLM Transformer example to use integer labels
- reduce vocab size and remove dataset shuffling

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685c0f9397b08331a6a0fecfe8ea694c