### PR TITLE
Switch to tensor-based attention

### DIFF
--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -44,7 +44,7 @@ describe SHAInet::MultiHeadAttention do
     input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
     mask = SHAInet::SimpleMatrix.from_a([[0.0, -1e9], [-1e9, 0.0]])
     out = attn.forward(input, mask)
-    expected = (input * attn.w_v) * attn.w_o
+    expected = (input * attn.w_v.to_simple) * attn.w_o.to_simple
     out.rows.times do |i|
       out.cols.times do |j|
         out[i, j].should be_close(expected[i, j], 1e-6)

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -430,10 +430,10 @@ module SHAInet
         blocks.each_with_index do |prefix, idx|
           t_layer = @transformer_layers[idx]
           mha = t_layer.mha
-          mha.w_q = SimpleMatrix.from_a(lookup["#{prefix}.mha.w_q"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
-          mha.w_k = SimpleMatrix.from_a(lookup["#{prefix}.mha.w_k"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
-          mha.w_v = SimpleMatrix.from_a(lookup["#{prefix}.mha.w_v"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
-          mha.w_o = SimpleMatrix.from_a(lookup["#{prefix}.mha.w_o"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+          mha.w_q = TensorMatrix.from_a(lookup["#{prefix}.mha.w_q"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+          mha.w_k = TensorMatrix.from_a(lookup["#{prefix}.mha.w_k"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+          mha.w_v = TensorMatrix.from_a(lookup["#{prefix}.mha.w_v"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
+          mha.w_o = TensorMatrix.from_a(lookup["#{prefix}.mha.w_o"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose
 
           ffn = t_layer.ffn
           ffn.w1 = SimpleMatrix.from_a(lookup["#{prefix}.ffn.w1"]["weight"].as_a.map { |r| r.as_a.map(&.as_f) }).transpose

--- a/src/shainet/basic/neuron.cr
+++ b/src/shainet/basic/neuron.cr
@@ -41,12 +41,16 @@ module SHAInet
     # Allows the neuron to absorb the activation from its' own input neurons through the synapses
     # Then, it sums the information and an activation function is applied to normalize the data
     def activate(activation_function : ActivationFunction = SHAInet.sigmoid) : Float64
-      sum = 0_f64
-      @synapses_in.each do |synapse| # Sum activation from each incoming neuron with applied weights
-        sum += synapse.propagate_forward
+      sum = Autograd::Tensor.new(0.0)
+      @synapses_in.each do |synapse|
+        sum = sum + Autograd::Tensor.new(synapse.propagate_forward)
       end
-      @input_sum = sum + @bias # Add neuron bias (activation threshold)
-      @activation, @sigma_prime = activation_function.call(@input_sum)
+      input_t = sum + Autograd::Tensor.new(@bias)
+      out, sig_p = activation_function.call(input_t.data)
+      @input_sum = input_t.data
+      @activation = out
+      @sigma_prime = sig_p
+      @activation
     end
 
     # This is the backward propogation of the hidden layers

--- a/src/shainet/math/tensor_matrix.cr
+++ b/src/shainet/math/tensor_matrix.cr
@@ -132,5 +132,19 @@ module SHAInet
       end
       dup
     end
+
+    def to_simple
+      m = SimpleMatrix.new(@rows, @cols)
+      @rows.times do |i|
+        @cols.times do |j|
+          m[i, j] = self[i, j].data
+        end
+      end
+      m
+    end
+
+    def zero_grads!
+      @data.each { |t| t.grad = 0.0 }
+    end
   end
 end

--- a/src/shainet/transformer/ext.cr
+++ b/src/shainet/transformer/ext.cr
@@ -1,18 +1,18 @@
 module SHAInet
   class MultiHeadAttention
-    def w_q=(m : SimpleMatrix)
+    def w_q=(m : TensorMatrix)
       @w_q = m
     end
 
-    def w_k=(m : SimpleMatrix)
+    def w_k=(m : TensorMatrix)
       @w_k = m
     end
 
-    def w_v=(m : SimpleMatrix)
+    def w_v=(m : TensorMatrix)
       @w_v = m
     end
 
-    def w_o=(m : SimpleMatrix)
+    def w_o=(m : TensorMatrix)
       @w_o = m
     end
   end

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -2,14 +2,12 @@ module SHAInet
   class MultiHeadAttention
     getter num_heads, d_model, head_dim
     @head_dim : Int32
-    @w_q : SimpleMatrix
-    @w_k : SimpleMatrix
-    @w_v : SimpleMatrix
-    @w_o : SimpleMatrix
-    @grads_w_q : SimpleMatrix
-    @grads_w_k : SimpleMatrix
-    @grads_w_v : SimpleMatrix
-    @grads_w_o : SimpleMatrix
+    @w_q : TensorMatrix
+    @w_k : TensorMatrix
+    @w_v : TensorMatrix
+    @w_o : TensorMatrix
+    @x_t : TensorMatrix?
+    @out_t : TensorMatrix
     @x : SimpleMatrix?
     @q_heads : Array(SimpleMatrix)
     @k_heads : Array(SimpleMatrix)
@@ -18,22 +16,15 @@ module SHAInet
     @out : SimpleMatrix
 
     getter w_q, w_k, w_v, w_o
-    property grads_w_q : SimpleMatrix
-    property grads_w_k : SimpleMatrix
-    property grads_w_v : SimpleMatrix
-    property grads_w_o : SimpleMatrix
 
     def initialize(@d_model : Int32, @num_heads : Int32)
       @head_dim = (@d_model // @num_heads)
       mat_klass = CUDA.available? ? CudaMatrix : SimpleMatrix
-      @w_q = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_k = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_v = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_o = mat_klass.new(@d_model, @d_model).random_fill!
-      @grads_w_q = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_k = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_v = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_o = mat_klass.zeros(@d_model, @d_model)
+      @w_q = mat_klass.tensor(@d_model, @d_model).random_fill!
+      @w_k = mat_klass.tensor(@d_model, @d_model).random_fill!
+      @w_v = mat_klass.tensor(@d_model, @d_model).random_fill!
+      @w_o = mat_klass.tensor(@d_model, @d_model).random_fill!
+      @out_t = mat_klass.tensor(1, 1)
       @q_heads = [] of SimpleMatrix
       @k_heads = [] of SimpleMatrix
       @v_heads = [] of SimpleMatrix
@@ -43,110 +34,97 @@ module SHAInet
 
     def forward(x : SimpleMatrix, mask : SimpleMatrix? = nil)
       @x = x
-      q = x * @w_q
-      k = x * @w_k
-      v = x * @w_v
+      @x_t = TensorMatrix.from_a(x.to_a)
+      q_t = @x_t.not_nil! * @w_q
+      k_t = @x_t.not_nil! * @w_k
+      v_t = @x_t.not_nil! * @w_v
+      q = x * @w_q.to_simple
+      k = x * @w_k.to_simple
+      v = x * @w_v.to_simple
 
       @q_heads = [] of SimpleMatrix
       @k_heads = [] of SimpleMatrix
       @v_heads = [] of SimpleMatrix
       @attn = [] of SimpleMatrix
       outputs = [] of SimpleMatrix
+      q_heads_t = [] of TensorMatrix
+      k_heads_t = [] of TensorMatrix
+      v_heads_t = [] of TensorMatrix
+      attn_t = [] of TensorMatrix
+      outputs_t = [] of TensorMatrix
 
       @num_heads.times do |h|
         qs = q.slice_cols(h*@head_dim, @head_dim)
         ks = k.slice_cols(h*@head_dim, @head_dim)
         vs = v.slice_cols(h*@head_dim, @head_dim)
+        qs_t = q_t.slice_cols(h*@head_dim, @head_dim)
+        ks_t = k_t.slice_cols(h*@head_dim, @head_dim)
+        vs_t = v_t.slice_cols(h*@head_dim, @head_dim)
         @q_heads << qs
         @k_heads << ks
         @v_heads << vs
+        q_heads_t << qs_t
+        k_heads_t << ks_t
+        v_heads_t << vs_t
 
         scores = qs * ks.transpose * (1.0 / Math.sqrt(@head_dim.to_f))
+        scores_t = qs_t * ks_t.transpose * (1.0 / Math.sqrt(@head_dim.to_f))
         if m = mask
           raise "mask size mismatch" unless m.rows == scores.rows && m.cols == scores.cols
           scores = scores + m
+          scores_t = scores_t + TensorMatrix.from_a(m.to_a)
         end
         attn = softmax_rows(scores)
+        attn_tensor = softmax_rows_tensor(scores_t)
         @attn << attn
+        attn_t << attn_tensor
         outputs << (attn * vs)
+        outputs_t << (attn_tensor * vs_t)
       end
 
       concat = SimpleMatrix.new(x.rows, @d_model)
+      concat_t = TensorMatrix.new(x.rows, @d_model)
       @num_heads.times do |h|
         concat.set_cols!(h*@head_dim, outputs[h])
+        concat_t.set_cols!(h*@head_dim, outputs_t[h])
       end
 
-      @out = concat * @w_o
+      @out_t = concat_t * @w_o
+      @out = concat * @w_o.to_simple
       @out
     end
 
     def backward(d_out : SimpleMatrix)
-      # Gradients for output projection
-      mat_klass = @w_q.class
-      @grads_w_o = (@q_heads.size == 0 ? mat_klass.zeros(@d_model, @d_model) : @grads_w_o)
-      @grads_w_o = @grads_w_o + ((@out.clone.transpose * d_out))
-      d_concat = d_out * @w_o.transpose
-
-      d_q_total = mat_klass.zeros(@x.not_nil!.rows, @d_model)
-      d_k_total = mat_klass.zeros(@x.not_nil!.rows, @d_model)
-      d_v_total = mat_klass.zeros(@x.not_nil!.rows, @d_model)
-
-      @num_heads.times do |h|
-        d_head = d_concat.slice_cols(h*@head_dim, @head_dim)
-        attn = @attn[h]
-        vs = @v_heads[h]
-        qs = @q_heads[h]
-        ks = @k_heads[h]
-
-        d_attn = d_head * vs.transpose
-        d_vs = attn.transpose * d_head
-
-        # softmax gradient
-        d_scores = mat_klass.zeros(attn.rows, attn.cols)
-        attn.rows.times do |i|
-          sum = 0.0
-          attn.cols.times do |j|
-            sum += attn[i, j] * d_attn[i, j]
-          end
-          attn.cols.times do |j|
-            d_scores[i, j] = attn[i, j]*(d_attn[i, j] - sum)
-          end
+      loss = Autograd::Tensor.new(0.0)
+      d_out.rows.times do |i|
+        d_out.cols.times do |j|
+          loss = loss + @out_t[i, j] * Autograd::Tensor.new(d_out[i, j])
         end
-        d_qs = d_scores * ks
-        d_ks = d_scores.transpose * qs
-
-        d_q_total.set_cols!(h*@head_dim, d_qs)
-        d_k_total.set_cols!(h*@head_dim, d_ks)
-        d_v_total.set_cols!(h*@head_dim, d_vs)
       end
-
-      @grads_w_q = @grads_w_q + (@x.not_nil!.transpose * d_q_total)
-      @grads_w_k = @grads_w_k + (@x.not_nil!.transpose * d_k_total)
-      @grads_w_v = @grads_w_v + (@x.not_nil!.transpose * d_v_total)
-
-      d_input = d_q_total * @w_q.transpose + d_k_total * @w_k.transpose + d_v_total * @w_v.transpose
-
-      d_input
+      loss.backward
+      grad_matrix = @x_t.not_nil!.clone
+      grad_matrix.rows.times do |i|
+        grad_matrix.cols.times do |j|
+          grad_matrix[i, j] = Autograd::Tensor.new(@x_t.not_nil![i, j].grad)
+        end
+      end
+      grad_matrix.to_simple
     end
 
     def apply_gradients(lr : Float64)
-      mat_klass = @w_q.class
-      @w_q = @w_q - @grads_w_q * lr
-      @w_k = @w_k - @grads_w_k * lr
-      @w_v = @w_v - @grads_w_v * lr
-      @w_o = @w_o - @grads_w_o * lr
-      @grads_w_q = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_k = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_v = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_o = mat_klass.zeros(@d_model, @d_model)
+      [@w_q, @w_k, @w_v, @w_o].each do |w|
+        w.rows.times do |i|
+          w.cols.times do |j|
+            t = w[i, j]
+            w[i, j] = Autograd::Tensor.new(t.data - lr * t.grad)
+            t.grad = 0.0
+          end
+        end
+      end
     end
 
     def zero_gradients
-      mat_klass = @w_q.class
-      @grads_w_q = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_k = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_v = mat_klass.zeros(@d_model, @d_model)
-      @grads_w_o = mat_klass.zeros(@d_model, @d_model)
+      [@w_q, @w_k, @w_v, @w_o].each &.zero_grads!
     end
 
     private def softmax_rows(m : SimpleMatrix)
@@ -155,6 +133,18 @@ module SHAInet
         sum = 0.0
         m.cols.times { |j| sum += Math.exp(m[i, j]) }
         m.cols.times { |j| result[i, j] = Math.exp(m[i, j]) / sum }
+      end
+      result
+    end
+
+    private def softmax_rows_tensor(m : TensorMatrix)
+      result = TensorMatrix.new(m.rows, m.cols)
+      m.rows.times do |i|
+        sum = Autograd::Tensor.new(0.0)
+        m.cols.times { |j| sum = sum + Autograd::Tensor.new(Math.exp(m[i, j].data)) }
+        m.cols.times do |j|
+          result[i, j] = Autograd::Tensor.new(Math.exp(m[i, j].data)) / sum
+        end
       end
       result
     end


### PR DESCRIPTION
## Summary
- extend `TensorMatrix` with conversion helpers and gradient clearing
- compute `Neuron` activation using `Tensor`
- refactor `MultiHeadAttention` to store `TensorMatrix` weights and derive
  gradients via autodiff
- update helpers and tests for new tensor behavior

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_685c16895f3c833186b09ac178d7a1db