### PR TITLE
Add autograd gradient check and autograd training spec

### DIFF
--- a/spec/autograd_numerical_spec.cr
+++ b/spec/autograd_numerical_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+
+private def f(x : Float64)
+  x * x + 3.0
+end
+
+describe SHAInet::Autograd::Tensor do
+  it "matches numerical gradient" do
+    x = SHAInet::Autograd::Tensor.new(2.0)
+    y = x * x + 3
+    y.backward
+    autograd_grad = x.grad
+
+    h = 1e-6
+    numeric = (f(x.data + h) - f(x.data - h)) / (2*h)
+    autograd_grad.should be_close(numeric, 1e-6)
+  end
+end

--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -703,6 +703,21 @@ describe SHAInet::Network do
   # #   puts "Correct answers: #{correct} / #{total}, Accuracy: #{(accuracy*100).round(3)}%"
   # #   (accuracy >= 0.2).should eq(true) # Without training acc is ~= 10%
   # # end
+
+  it "trains a simple transformer network using autograd" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2, :memory, SHAInet.none)
+    net.add_layer(:transformer, 2)
+    net.add_layer(:output, 2, :memory, SHAInet.none)
+    training = [[[[1.0, 0.0]], [1.0, 1.0]]]
+    net.learning_rate = 0.1
+    net.train(data: training, training_type: :sgdm,
+      epochs: 2000, mini_batch_size: 1, log_each: 2000)
+    out = net.run([[1.0, 0.0]]).last
+    out[0].should be_close(1.0, 0.1)
+    out[1].should be_close(1.0, 0.1)
+  end
 end
 
 # Remove train data


### PR DESCRIPTION
## Summary
- add a numerical gradient test for `Autograd::Tensor`
- exercise transformer based network training in network specs

## Testing
- `crystal spec spec/autograd_numerical_spec.cr spec/autograd_tensor_spec.cr spec/matrix_autograd_spec.cr spec/rnn_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_685c2622dd70833181dd14c7a68feac1