### PR TITLE
Fix transformer embedding sequence handling

### DIFF
--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -115,4 +115,20 @@ describe "Network with TransformerLayer" do
     out[0].should be_close(1.0, 0.1)
     out[1].should be_close(1.0, 0.1)
   end
+
+  it "works with embeddings and positional encoding" do
+    Random::DEFAULT.new_seed(42_u64, 54_u64)
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:embedding, 2, :memory, SHAInet.none)
+    net.add_layer(:transformer, 2)
+    net.add_layer(:output, 2, :memory, SHAInet.none)
+    net.fully_connect
+
+    pe = SHAInet::PositionalEncoding.sinusoidal(2, 2)
+    net.transformer_layers.each { |l| l.positional_encoding = pe }
+
+    out = net.run([[1.0], [2.0]]).last
+    out.size.should eq(2)
+  end
 end


### PR DESCRIPTION
## Summary
- fix embedding use inside `Network#run` when transformers are used
- support embedding layers in sequence runs with transformers
- test transformer layers with embeddings and positional encodings

## Testing
- `crystal spec spec/transformer_spec.cr --order random`


------
https://chatgpt.com/codex/tasks/task_e_685c2b7674788331828d3ac9bc1be454