### PR TITLE
Fix label bounds check

### DIFF
--- a/spec/invalid_label_spec.cr
+++ b/spec/invalid_label_spec.cr
@@ -1,0 +1,25 @@
+require "./spec_helper"
+
+describe SHAInet::Network do
+  it "raises when label index is out of bounds" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:output, 2, :memory, SHAInet.sigmoid)
+    net.fully_connect
+
+    expect_raises(SHAInet::NeuralNetRunError) do
+      net.evaluate_label([0], 3)
+    end
+  end
+
+  it "raises when sequence label index is out of bounds" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 1, :memory, SHAInet.none)
+    net.add_layer(:output, 2, :memory, SHAInet.sigmoid)
+    net.fully_connect
+
+    expect_raises(SHAInet::NeuralNetRunError) do
+      net.evaluate_sequence_label([[0]], 3)
+    end
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -251,6 +251,10 @@ module SHAInet
       validate_values(actual_output, "actual_output")
       probs = SHAInet.softmax(actual_output)
 
+      if label < 0 || label >= probs.size
+        raise NeuralNetRunError.new("Label #{label} out of bounds for output size #{probs.size}")
+      end
+
       @error_signal = [] of Float64
       probs.size.times do |i|
         neuron = @output_layers.last.neurons[i]
@@ -278,6 +282,10 @@ module SHAInet
       actual_output = outputs.last
       validate_values(actual_output, "actual_output")
       probs = SHAInet.softmax(actual_output)
+
+      if label < 0 || label >= probs.size
+        raise NeuralNetRunError.new("Label #{label} out of bounds for output size #{probs.size}")
+      end
 
       @error_signal = [] of Float64
       probs.size.times do |i|


### PR DESCRIPTION
## Summary
- prevent index errors when labels exceed output size
- add tests for invalid label handling

## Testing
- `crystal spec spec/invalid_label_spec.cr`
- `crystal spec` *(failed: took too long, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685c5760ccdc8331bb53277e71ef19c3