### PR TITLE
Switch embedding layer to matrix storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ ids_matrix = tokenizer.encode_matrix("hello world hello")
 
 net = SHAInet::Network.new
 net.add_layer(:input, 1)
-net.add_layer(:embedding, 8) # 8 dimensional embeddings
+net.add_layer(:embedding, 8, vocab_size: tokenizer.vocab.size) # 8 dimensional embeddings
 net.add_layer(:lstm, 4)
 net.add_layer(:output, 1)
 net.fully_connect

--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -34,7 +34,7 @@ seq_len = 16
 token_count = tokenizer.vocab.size
 net = SHAInet::Network.new
 net.add_layer(:input, 1, :memory, SHAInet.none)
-net.add_layer(:embedding, d_model, :memory, SHAInet.none)
+net.add_layer(:embedding, d_model, :memory, SHAInet.none, vocab_size: token_count)
 4.times { net.add_layer(:transformer, d_model) }
 # Use a sigmoid output so cross-entropy can be applied per token
 net.add_layer(:output, token_count, :memory, SHAInet.identity)

--- a/examples/llm_sample.cr
+++ b/examples/llm_sample.cr
@@ -19,7 +19,7 @@ ids = tokenizer.encode(text)
 token_count = tokenizer.vocab.size
 net = SHAInet::Network.new
 net.add_layer(:input, 1, :memory, SHAInet.none)
-net.add_layer(:embedding, 8, :memory, SHAInet.none)
+net.add_layer(:embedding, 8, :memory, SHAInet.none, vocab_size: token_count)
 net.add_layer(:lstm, 16)
 net.add_layer(:output, token_count, :memory, SHAInet.sigmoid)
 net.fully_connect

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -19,7 +19,7 @@ token_count = tokenizer.vocab.size
 
 net = SHAInet::Network.new
 net.add_layer(:input, 1, :memory, SHAInet.none)
-net.add_layer(:embedding, 8, :memory, SHAInet.none)
+net.add_layer(:embedding, 8, :memory, SHAInet.none, vocab_size: token_count)
 net.add_layer(:transformer, 8)
 net.add_layer(:output, token_count, :memory, SHAInet.sigmoid)
 net.fully_connect

--- a/spec/embedding_layer_spec.cr
+++ b/spec/embedding_layer_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe SHAInet::EmbeddingLayer do
   it "returns consistent embeddings" do
-    layer = SHAInet::EmbeddingLayer.new(4)
+    layer = SHAInet::EmbeddingLayer.new(5, 4)
     first = layer.embed(1)
     second = layer.embed(1)
     first.should eq(second)
@@ -12,7 +12,7 @@ describe SHAInet::EmbeddingLayer do
   it "updates embeddings during training" do
     net = SHAInet::Network.new
     net.add_layer(:input, 1, :memory, SHAInet.none)
-    net.add_layer(:embedding, 2, :memory, SHAInet.none)
+    net.add_layer(:embedding, 2, :memory, SHAInet.none, vocab_size: 3)
     net.add_layer(:output, 1, :memory, SHAInet.none)
     net.fully_connect
 
@@ -23,7 +23,7 @@ describe SHAInet::EmbeddingLayer do
     net.learning_rate = 0.1
     net.train(data: training, training_type: :sgdm, epochs: 1, mini_batch_size: 1, log_each: 1)
 
-    after = layer.embeddings[1]
+    after = layer.lookup(1)
     after.should_not eq(before)
   end
 end

--- a/spec/llm_integration_spec.cr
+++ b/spec/llm_integration_spec.cr
@@ -20,7 +20,7 @@ describe "LLM integration" do
 
     net = SHAInet::Network.new
     net.add_layer(:input, 1, :memory, SHAInet.none)
-    net.add_layer(:embedding, 8)
+    net.add_layer(:embedding, 8, vocab_size: tokenizer.vocab.size)
     net.add_layer(:lstm, 16)
     net.add_layer(:output, tokenizer.vocab.size, :memory, SHAInet.sigmoid)
     net.fully_connect

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -121,7 +121,7 @@ describe "Network with TransformerLayer" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     net = SHAInet::Network.new
     net.add_layer(:input, 1, :memory, SHAInet.none)
-    net.add_layer(:embedding, 2, :memory, SHAInet.none)
+    net.add_layer(:embedding, 2, :memory, SHAInet.none, vocab_size: 3)
     net.add_layer(:transformer, 2)
     net.add_layer(:output, 2, :memory, SHAInet.none)
     net.fully_connect

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -1,52 +1,63 @@
 module SHAInet
   # Simple embedding lookup table. Maps integer token IDs to vectors of floats.
   class EmbeddingLayer < Layer
-    property embeddings : Hash(Int32, Array(Float64))
-    property gradients : Hash(Int32, Array(Float64))
+    property embeddings : SimpleMatrix
+    property gradients : SimpleMatrix
     getter current_ids : Array(Int32)
 
-    def initialize(l_size : Int32, activation_function : ActivationFunction = SHAInet.none)
+    def initialize(vocab_size : Int32, l_size : Int32, activation_function : ActivationFunction = SHAInet.none)
       super("memory", l_size, activation_function)
-      @embeddings = Hash(Int32, Array(Float64)).new
-      @gradients = Hash(Int32, Array(Float64)).new
+      mat_klass = CUDA.available? ? CudaMatrix : SimpleMatrix
+      @embeddings = mat_klass.new(vocab_size, l_size).random_fill!
+      @gradients = mat_klass.zeros(vocab_size, l_size)
       @current_ids = [] of Int32
+    end
+
+    # Migration helper for legacy models using hash based storage
+    def self.from_hash(hash : Hash(Int32, Array(Float64)), activation_function : ActivationFunction = SHAInet.none)
+      vocab_size = hash.keys.max? ? hash.keys.max + 1 : 0
+      l_size = hash.values.first?.try(&.size) || 0
+      layer = new(vocab_size, l_size, activation_function)
+      hash.each do |id, vals|
+        vals.each_with_index { |v, i| layer.embeddings[id, i] = v }
+      end
+      layer
     end
 
     # Retrieve embedding vector for the given token id. If the token id does not
     # exist in the table, it is initialized with random values.
     def lookup(id : Int32) : Array(Float64)
-      @embeddings[id] ||= Array(Float64).new(@l_size) { rand(-0.1_f64..0.1_f64) }
+      Array.new(@l_size) { |i| @embeddings[id, i] }
     end
 
     # Set the neuron activations for this layer according to the embedding of the
     # provided token id. Returns the embedding vector.
     def embed(id : Int32) : Array(Float64)
-      vec = lookup(id)
-      vec.each_with_index do |v, i|
-        @neurons[i].activation = v
+      @neurons.each_with_index do |n, i|
+        n.activation = @embeddings[id, i]
       end
       @current_ids << id
-      vec
+      lookup(id)
     end
 
     # Accumulate gradient for the last embedded ids
     def accumulate_gradient
       until @current_ids.empty?
         id = @current_ids.shift
-        grad = @gradients[id] ||= Array(Float64).new(@l_size, 0.0)
         @neurons.each_with_index do |n, i|
-          grad[i] += n.gradient
+          @gradients[id, i] += n.gradient
         end
       end
     end
 
     # Update embeddings using stored gradients and clear them
     def apply_gradients(lr : Float64)
-      @gradients.each do |id, grad|
-        emb = lookup(id)
-        grad.each_with_index do |g, i|
-          emb[i] -= lr*g
-          grad[i] = 0.0
+      @gradients.rows.times do |r|
+        @gradients.cols.times do |c|
+          g = @gradients[r, c]
+          next if g == 0.0
+          @embeddings[r, c] -= lr * g
+          @gradients[r, c] = 0.0
         end
       end
     end


### PR DESCRIPTION
## Summary
- store embeddings in a matrix instead of a hash
- require `vocab_size` when adding an embedding layer
- update embedding lookup, gradient accumulation and updates
- allow migrating old hash-based embeddings
- update examples, specs and README

## Testing
- `crystal spec spec/embedding_layer_spec.cr -v`

------
https://chatgpt.com/codex/tasks/task_e_685d0f1352e88331abb40c66c09e74f1