### PR TITLE
Fix call to cuBLAS ger routine

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -33,7 +33,7 @@ module SHAInet
                       c : Pointer(Float64), ldc : Int32) : Int32
       fun cublasDscal_v2(handle : Handle, n : Int32,
                          alpha : Pointer(Float64), x : Pointer(Float64), incx : Int32) : Int32
-      fun cublasDger(handle : Handle,
+      fun cublasDger_v2(handle : Handle,
                      m : Int32, n : Int32,
                      alpha : Pointer(Float64),
                      x : Pointer(Float64), incx : Int32,
@@ -194,7 +194,7 @@ module SHAInet
     end
 
     def ger(handle : LibCUBLAS::Handle, x : Pointer(Float64), y : Pointer(Float64), a : Pointer(Float64), m : Int32, n : Int32, lda : Int32, alpha : Float64 = 1.0)
-      LibCUBLAS.cublasDger(handle, m, n, pointerof(alpha), x, 1, y, 1, a, lda)
+      LibCUBLAS.cublasDger_v2(handle, m, n, pointerof(alpha), x, 1, y, 1, a, lda)
     end
 
     def dot(handle : LibCUBLAS::Handle, x : Pointer(Float64), y : Pointer(Float64), n : Int32)


### PR DESCRIPTION
## Summary
- use `cublasDger_v2` to pass cuBLAS handle correctly

## Testing
- `crystal spec spec/cuda_matrix_spec.cr -v`
- `crystal spec spec/embedding_cuda_parity_spec.cr -v`
- `crystal spec spec/embedding_layer_spec.cr -v`
- `crystal spec spec/positionwise_ff_cuda_parity_spec.cr -v`
- `crystal spec > /tmp/spec.log && tail -n 20 /tmp/spec.log`

------
https://chatgpt.com/codex/tasks/task_e_685d7f65b0e883318c2bfc92c94243e4