### PR TITLE
Remove Apatite dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,9 +8,6 @@ authors:
 crystal: 1.6.2
 
 dependencies:
-  apatite:
-    github: watzon/apatite
-    branch: master
 
 development_dependencies:
   ameba:

--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -1,10 +1,8 @@
 require "log"
 require "./shainet/**"
-require "apatite"
 
 module SHAInet
   Log = ::Log.for(self)
-  include Apatite
   alias GenNum = Float64 | Int32 | Int64 | Float32
 
   ::Log.setup(:debug)

--- a/src/shainet/basic/layer.cr
+++ b/src/shainet/basic/layer.cr
@@ -1,25 +1,24 @@
-require "apatite"
+require "../math/simple_matrix"
 
 module SHAInet
   class Layer
-    include Apatite
     Log = ::Log.for(self)
 
     property :n_type, :neurons
     getter :activation_function, :l_size
-    property input_sums : Matrix(Float64), weights : Matrix(Float64), biases : Matrix(Float64)
-    getter activations : Matrix(Float64), sigma_primes : Matrix(Float64)
+    property input_sums : SimpleMatrix, weights : SimpleMatrix, biases : SimpleMatrix
+    getter activations : SimpleMatrix, sigma_primes : SimpleMatrix
 
     def initialize(@n_type : String, @l_size : Int32, @activation_function : ActivationFunction = SHAInet.sigmoid)
       @neurons = Array(Neuron).new
 
       # ------- Experimental -------
       # Pointer matrices for forward propogation
-      @input_sums = Matrix(Float64).build(1, @l_size) { 0.0 }
-      @weights = Matrix(Float64).build(1, @l_size) { 0.0 }
-      @biases = Matrix(Float64).build(1, @l_size) { 0.0 }
-      @activations = Matrix(Float64).build(1, @l_size) { 0.0 }
-      @sigma_primes = Matrix(Float64).build(1, @l_size) { 0.0 }
+      @input_sums = SimpleMatrix.new(1, @l_size, 0.0)
+      @weights = SimpleMatrix.new(1, @l_size, 0.0)
+      @biases = SimpleMatrix.new(1, @l_size, 0.0)
+      @activations = SimpleMatrix.new(1, @l_size, 0.0)
+      @sigma_primes = SimpleMatrix.new(1, @l_size, 0.0)
 
       # # Pointer matrices for back propogation
       # @w_gradients = Array(Array(Pointer)).new
@@ -45,10 +44,10 @@ module SHAInet
 
       # ------- Experimental -------
       # Transpose the needed matrices
-      @input_sums.t
-      @biases.t
-      @activations.t
-      @sigma_primes.t
+      @input_sums.transpose
+      @biases.transpose
+      @activations.transpose
+      @sigma_primes.transpose
     end
 
     def clone

--- a/src/shainet/transformer/ext.cr
+++ b/src/shainet/transformer/ext.cr
@@ -1,18 +1,18 @@
 module SHAInet
   class MultiHeadAttention
-    def w_q=(m : TensorMatrix)
+    def w_q=(m : SimpleMatrix)
       @w_q = m
     end
 
-    def w_k=(m : TensorMatrix)
+    def w_k=(m : SimpleMatrix)
       @w_k = m
     end
 
-    def w_v=(m : TensorMatrix)
+    def w_v=(m : SimpleMatrix)
       @w_v = m
     end
 
-    def w_o=(m : TensorMatrix)
+    def w_o=(m : SimpleMatrix)
       @w_o = m
     end
   end


### PR DESCRIPTION
## Summary
- drop Apatite shard
- use `SimpleMatrix` everywhere in `Layer`
- create weight/bias matrices with `SimpleMatrix` or `CudaMatrix`
- update transformer helpers for new matrix types
- adjust loader to build simple matrices

## Testing
- `CRYSTAL_WORKERS=1 crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686142e965ac833196decd250550bb8b