### PR TITLE
Refactor GPU memory ops

### DIFF
--- a/spec/cuda_matrix_spec.cr
+++ b/spec/cuda_matrix_spec.cr
@@ -2,8 +2,8 @@ require "./spec_helper"
 
 describe SHAInet::CudaMatrix do
   it "mirrors SimpleMatrix operations" do
-    a = SHAInet::CudaMatrix.from_a([[1, 2], [3, 4]])
-    b = SHAInet::CudaMatrix.from_a([[1, 0], [0, 1]])
+    a = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1, 2], [3, 4]]))
+    b = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1, 0], [0, 1]]))
 
     sum = a + b
     sum[1, 1].should eq(5.0)
@@ -17,14 +17,14 @@ describe SHAInet::CudaMatrix do
   end
 
   it "performs relu and add_bias on GPU when available" do
-    matrix = SHAInet::CudaMatrix.from_a([[-1, 2], [-3, 4]])
-    bias = SHAInet::CudaMatrix.from_a([[1, 1]])
+    matrix = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[-1, 2], [-3, 4]]))
+    bias = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1, 1]]))
 
     matrix.relu!
     matrix.add_bias!(bias)
 
     if SHAInet::CUDA.available?
-      matrix.device_ptr.should_not be_nil
+      matrix.as(SHAInet::CudaMatrix).device_ptr.should_not be_nil
     end
 
     matrix[0, 0].should eq(0.0 + 1.0)

--- a/spec/cuda_softmax_dropout_spec.cr
+++ b/spec/cuda_softmax_dropout_spec.cr
@@ -4,9 +4,9 @@ describe "CUDA softmax and dropout" do
   it "matches CPU softmax" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
     cpu = SHAInet::SimpleMatrix.from_a([[1.0, 2.0], [3.0, 4.0]])
-    gpu = SHAInet::CudaMatrix.from_a(cpu.to_a)
+    gpu = SHAInet::GPUMemory.to_gpu(cpu)
     gpu_out = SHAInet.softmax_rows(gpu)
-    gpu_out.sync_from_device!
+    SHAInet::GPUMemory.batch_sync_from_device([gpu_out])
     cpu_out = SHAInet.softmax_rows(cpu)
     cpu_out.rows.times do |i|
       cpu_out.cols.times do |j|
@@ -17,12 +17,12 @@ describe "CUDA softmax and dropout" do
 
   it "drops approximately the given percentage" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
-    mat = SHAInet::CudaMatrix.ones(10, 10)
+    mat = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(10, 10))
     runs = 200
     total_ratio = 0.0
     runs.times do
       out = SHAInet::TransformerDropout.apply(mat, 30)
-      out.sync_from_device!
+      SHAInet::GPUMemory.batch_sync_from_device([out])
       dropped = 0
       mat.rows.times do |i|
         mat.cols.times do |j|

--- a/spec/embedding_cuda_lookup_spec.cr
+++ b/spec/embedding_cuda_lookup_spec.cr
@@ -7,7 +7,7 @@ describe "Embedding GPU lookup" do
     ids = [1, 3]
     matrix = layer.embed(ids)
     matrix.should be_a(SHAInet::CudaMatrix)
-    matrix.as(SHAInet::CudaMatrix).sync_from_device!
+    SHAInet::GPUMemory.batch_sync_from_device([matrix])
     ids.each_with_index do |id, row|
       layer.lookup(id).each_with_index do |val, col|
         matrix[row, col].should be_close(val, 1e-6)

--- a/spec/multi_head_attention_cuda_spec.cr
+++ b/spec/multi_head_attention_cuda_spec.cr
@@ -11,7 +11,7 @@ describe "MultiHeadAttention GPU parity" do
     ENV.delete("SHAINET_DISABLE_CUDA")
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     gpu_attn = SHAInet::MultiHeadAttention.new(2, 1)
-    gpu_in = SHAInet::CudaMatrix.from_a(input.to_a)
+    gpu_in = SHAInet::GPUMemory.to_gpu(input)
     gpu_out = gpu_attn.forward(gpu_in)
     cpu_out.rows.times do |i|
       cpu_out.cols.times do |j|

--- a/spec/positionwise_ff_cuda_parity_spec.cr
+++ b/spec/positionwise_ff_cuda_parity_spec.cr
@@ -23,8 +23,8 @@ describe "PositionWiseFF GPU parity" do
     ENV.delete("SHAINET_DISABLE_CUDA")
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     gpu_ff = SHAInet::PositionWiseFF.new(4, 6)
-    x_gpu = SHAInet::CudaMatrix.from_a(x_cpu.to_a)
-    dout_gpu = SHAInet::CudaMatrix.ones(2, 4)
+    x_gpu = SHAInet::GPUMemory.to_gpu(x_cpu)
+    dout_gpu = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(2, 4))
     gpu_ff.forward(x_gpu)
     gpu_ff.backward(dout_gpu)
     gb1_gpu = gpu_ff.g_b1.clone

--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -51,7 +51,7 @@ module SHAInet
       if CUDA.available? && CUDA.kernels_available? && d_out.is_a?(CudaMatrix) && @g_b2.is_a?(CudaMatrix)
         begin
           CUDA.row_sum(@g_b2.as(CudaMatrix).device_ptr.not_nil!, d_out.as(CudaMatrix).device_ptr.not_nil!, d_out.rows, d_out.cols)
-          @g_b2.as(CudaMatrix).sync_from_device!
+          GPUMemory.batch_sync_from_device([@g_b2])
         rescue e : Exception
           # Fallback to CPU computation
           d_out.rows.times do |i|
@@ -75,7 +75,7 @@ module SHAInet
       if CUDA.available? && CUDA.kernels_available? && drelu.is_a?(CudaMatrix) && @g_b1.is_a?(CudaMatrix)
         begin
           CUDA.row_sum(@g_b1.as(CudaMatrix).device_ptr.not_nil!, drelu.as(CudaMatrix).device_ptr.not_nil!, drelu.rows, drelu.cols)
-          @g_b1.as(CudaMatrix).sync_from_device!
+          GPUMemory.batch_sync_from_device([@g_b1])
         rescue e : Exception
           # Fallback to CPU computation
           drelu.rows.times do |i|


### PR DESCRIPTION
## Summary
- improve transformer GPU memory handling via GPUMemory helpers
- batch device syncs in transformer layers
- update examples for GPU-friendly workflow
- adjust specs to use new GPU memory utilities

## Testing
- `crystal spec spec/cuda_matrix_spec.cr --order random`
- `crystal spec spec/embedding_cuda_lookup_spec.cr --order random`
- `crystal spec spec/cuda_softmax_dropout_spec.cr --order random`
- `crystal spec spec/multi_head_attention_cuda_spec.cr --order random`
- `crystal spec spec/positionwise_ff_cuda_parity_spec.cr --order random`

------
https://chatgpt.com/codex/tasks/task_e_68615b4c85f883318e9603311db9e3ac