### PR TITLE
Fix babylm example header

### DIFF
--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -1,16 +1,4 @@
 require "../src/shainet"
-require "log"
-# BabyLM challenge example (GPU-optimized)
-# ------------------------
-# This example has been optimized for better GPU utilization.
-#
-# For maximum performance:
-# 1. Run: make install (builds CUDA kernels)
-# 2. Set library path: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)
-# 3. Monitor GPU usage: nvidia-smi -l 1
-#
-# 1. Download the BabyLM training set from the following URL:src/shainet"
-require "log"
 # BabyLM challenge example (GPU-optimized)
 # ------------------------
 # This example has been optimized for better GPU utilization.


### PR DESCRIPTION
## Summary
- remove duplicated intro comments
- drop stray `require "log"`

## Testing
- `crystal build examples/babylm_transformer.cr -o /tmp/babylm_example`
- `crystal spec --order=random` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68618cc1fe608331b051d6edf5bce029