### PR TITLE
Add simple GPU memory pool

### DIFF
--- a/benchmarks/pool_allocator_benchmark.cr
+++ b/benchmarks/pool_allocator_benchmark.cr
@@ -1,0 +1,31 @@
+require "../src/shainet"
+
+ROWS  =  256
+COLS  =  256
+COUNT = 1000
+
+puts "CUDA available: #{SHAInet::CUDA.available?}"
+
+def allocate(count)
+  count.times do
+    m = SHAInet::CudaMatrix.new(ROWS, COLS)
+    m.finalize
+  end
+end
+
+# Without pooling
+SHAInet::GPUMemory.pool_limit = 0
+SHAInet::GPUMemory.cleanup
+start = Time.monotonic
+allocate(COUNT)
+no_pool = Time.monotonic - start
+
+# With pooling
+SHAInet::GPUMemory.pool_limit = COUNT
+SHAInet::GPUMemory.preallocate!(ROWS, COLS, COUNT)
+start = Time.monotonic
+allocate(COUNT)
+with_pool = Time.monotonic - start
+
+puts "Allocate #{COUNT} matrices without pool: #{no_pool.total_milliseconds}ms"
+puts "Allocate #{COUNT} matrices with pool: #{with_pool.total_milliseconds}ms"


### PR DESCRIPTION
## Summary
- design buffer allocator in `GPUMemory`
- use the allocator in `CudaMatrix`
- preallocate batch buffers in `Network.train`
- cleanup buffers after training
- add benchmark for pooling overhead

## Testing
- `crystal spec` *(fails: environment hang)*

------
https://chatgpt.com/codex/tasks/task_e_68618cc9258c8331b50ccc233959477a