### PR TITLE
Refactor BPE merge loops

### DIFF
--- a/spec/bpe_tokenizer_spec.cr
+++ b/spec/bpe_tokenizer_spec.cr
@@ -7,4 +7,12 @@ describe SHAInet::BPETokenizer do
     encoded = tokenizer.encode("hello world")
     tokenizer.decode(encoded).should eq("hello world")
   end
+
+  it "merges tokens correctly on long sequences" do
+    tokenizer = SHAInet::BPETokenizer.new
+    long_word = "ab" * 50
+    tokenizer.train(long_word, 100)
+    ids = tokenizer.encode(long_word)
+    tokenizer.decode(ids).should eq(long_word)
+  end
 end

--- a/src/shainet/text/bpe_tokenizer.cr
+++ b/src/shainet/text/bpe_tokenizer.cr
@@ -74,10 +74,17 @@ module SHAInet
         end
         corpus.each do |tokens|
           i = 0
-          while i < tokens.size - 1
+          size = tokens.size
+          while i < size - 1
             if tokens[i] == token_a && tokens[i + 1] == token_b
               tokens[i] = new_token
-              tokens.delete_at(i + 1)
+              j = i + 1
+              while j < size - 1
+                tokens[j] = tokens[j + 1]
+                j += 1
+              end
+              tokens.pop
+              size -= 1
             else
               i += 1
             end
@@ -161,10 +168,17 @@ module SHAInet
         io << pair[1]
       end
       i = 0
-      while i < tokens.size - 1
+      size = tokens.size
+      while i < size - 1
         if tokens[i] == pair[0] && tokens[i + 1] == pair[1]
           tokens[i] = new_token
-          tokens.delete_at(i + 1)
+          j = i + 1
+          while j < size - 1
+            tokens[j] = tokens[j + 1]
+            j += 1
+          end
+          tokens.pop
+          size -= 1
         else
           i += 1
         end


### PR DESCRIPTION
## Summary
- rewrite BPE training merge loop to avoid `delete_at`
- update `merge_tokens!` to shift tokens in-place
- add spec for merging of long sequences

## Testing
- `crystal spec spec/bpe_tokenizer_spec.cr -v`
- `crystal spec spec/bpe_tokenizer_spec.cr spec/bpe_tokenizer_detailed_spec.cr -v`


------
https://chatgpt.com/codex/tasks/task_e_686275bce5588331ba81ed2111369bc9