### PR TITLE
Implement BatchProcessor with matrix utilities

### DIFF
--- a/spec/batch_processor_spec.cr
+++ b/spec/batch_processor_spec.cr
@@ -1,0 +1,28 @@
+require "./spec_helper"
+
+describe SHAInet::BatchProcessor do
+  it "matches individual layer forward passes" do
+    mat_klass = SHAInet::CUDA.available? ? SHAInet::CudaMatrix : SHAInet::SimpleMatrix
+    layer1 = SHAInet::MatrixLayer.new(2, 3)
+    layer2 = SHAInet::MatrixLayer.new(2, 3)
+
+    input1 = mat_klass.from_a([[1.0, 2.0]])
+    input2 = mat_klass.from_a([[3.0, 4.0]])
+
+    out1 = layer1.forward(input1)
+    out2 = layer2.forward(input2)
+
+    batch_out = SHAInet::BatchProcessor.process_batch([layer1, layer2], [input1, input2])
+
+    batch_out.size.should eq 2
+
+    [out1, out2].each_with_index do |expected, idx|
+      result = batch_out[idx]
+      expected.rows.times do |i|
+        expected.cols.times do |j|
+          result[i, j].should be_close(expected[i, j], 1e-6)
+        end
+      end
+    end
+  end
+end

--- a/src/shainet/math/batch_processor.cr
+++ b/src/shainet/math/batch_processor.cr
@@ -1,0 +1,18 @@
+module SHAInet
+  # BatchProcessor helps run multiple MatrixLayer forward passes
+  # in a convenient single call. It simply forwards each input
+  # through the corresponding layer and returns the outputs.
+  class BatchProcessor
+    alias MatrixData = SimpleMatrix | CudaMatrix
+
+    def self.process_batch(layers : Array(MatrixLayer), inputs : Array(MatrixData))
+      raise ArgumentError.new("size mismatch") unless layers.size == inputs.size
+
+      outputs = [] of MatrixData
+      layers.each_with_index do |layer, idx|
+        outputs << layer.forward(inputs[idx])
+      end
+      outputs
+    end
+  end
+end

--- a/src/shainet/math/unified_matrix.cr
+++ b/src/shainet/math/unified_matrix.cr
@@ -1,8 +1,57 @@
+require "./simple_matrix"
+require "./cuda_matrix"
+
 module SHAInet
   abstract class UnifiedMatrix
     abstract def forward(input : UnifiedMatrix) : UnifiedMatrix
     abstract def backward(grad : UnifiedMatrix) : UnifiedMatrix
     abstract def update_weights(lr : Float64)
+
+    alias MatrixData = SimpleMatrix | CudaMatrix
+
+    # Stack matrices vertically into a single matrix. The returned
+    # matrix keeps the same device type (CPU/GPU) as the inputs.
+    def self.stack(matrices : Array(MatrixData)) : MatrixData
+      raise ArgumentError.new("no matrices to stack") if matrices.empty?
+
+      cols = matrices.first.cols
+      total_rows = 0
+      matrices.each do |m|
+        raise ArgumentError.new("column mismatch") unless m.cols == cols
+        total_rows += m.rows
+      end
+
+      result = matrices.first.is_a?(CudaMatrix) ? CudaMatrix.new(total_rows, cols) : SimpleMatrix.new(total_rows, cols)
+
+      offset = 0
+      matrices.each do |m|
+        m.rows.times do |i|
+          cols.times do |j|
+            result[offset + i, j] = m[i, j]
+          end
+        end
+        offset += m.rows
+      end
+
+      result
+    end
+
+    # Split a stacked matrix back into an array of matrices using the
+    # provided row counts.
+    def self.unstack(matrix : MatrixData, rows : Array(Int32)) : Array(MatrixData)
+      parts = [] of MatrixData
+      offset = 0
+      rows.each do |r|
+        part = matrix.is_a?(CudaMatrix) ? CudaMatrix.new(r, matrix.cols) : SimpleMatrix.new(r, matrix.cols)
+        r.times do |i|
+          matrix.cols.times do |j|
+            part[i, j] = matrix[offset + i, j]
+          end
+        end
+        offset += r
+        parts << part
+      end
+      parts
+    end
   end
 end
-


### PR DESCRIPTION
## Summary
- add `BatchProcessor` for running multiple `MatrixLayer` forwards
- extend `UnifiedMatrix` with `stack` and `unstack` helpers
- add spec verifying batch processing behavior

## Testing
- `crystal spec spec/batch_processor_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68638bbd82408331b59dd2baf97d9ca4