### PR TITLE
Add basic matrix-based network

### DIFF
--- a/spec/network_matrix_spec.cr
+++ b/spec/network_matrix_spec.cr
@@ -1,0 +1,66 @@
+require "./spec_helper"
+
+describe SHAInet::Network do
+  it "performs forward and backward passes" do
+    mat_klass = SHAInet::CUDA.available? ? SHAInet::CudaMatrix : SHAInet::SimpleMatrix
+
+    net = SHAInet::Network.new
+    l1 = net.add_layer(2, 3)
+    l2 = net.add_layer(3, 1)
+
+    l1.weights = mat_klass.from_a([
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ])
+    l1.biases = mat_klass.from_a([[0.1, 0.2, 0.3]])
+
+    l2.weights = mat_klass.from_a([
+      [0.7],
+      [0.8],
+      [0.9],
+    ])
+    l2.biases = mat_klass.from_a([[0.4]])
+
+    input = mat_klass.from_a([[1.0, 2.0]])
+    out = net.forward(input)
+
+    expected_hidden = [
+      1*0.1 + 2*0.4 + 0.1,
+      1*0.2 + 2*0.5 + 0.2,
+      1*0.3 + 2*0.6 + 0.3,
+    ]
+    expected_output = [
+      expected_hidden[0]*0.7 + expected_hidden[1]*0.8 + expected_hidden[2]*0.9 + 0.4,
+    ]
+    out[0,0].should be_close(expected_output[0], 1e-6)
+
+    grad_out = mat_klass.ones(1,1)
+    grad_in = net.backward(grad_out)
+
+    # check gradients of last layer
+    l2.g_w[0,0].should be_close(expected_hidden[0], 1e-6)
+    l2.g_w[1,0].should be_close(expected_hidden[1], 1e-6)
+    l2.g_w[2,0].should be_close(expected_hidden[2], 1e-6)
+    l2.g_b[0,0].should be_close(1.0, 1e-6)
+
+    # gradients for first layer
+    l1.g_w[0,0].should be_close(1.0*0.7, 1e-6)
+    l1.g_w[0,1].should be_close(1.0*0.8, 1e-6)
+    l1.g_w[0,2].should be_close(1.0*0.9, 1e-6)
+    l1.g_w[1,0].should be_close(2.0*0.7, 1e-6)
+    l1.g_w[1,1].should be_close(2.0*0.8, 1e-6)
+    l1.g_w[1,2].should be_close(2.0*0.9, 1e-6)
+    l1.g_b[0,0].should be_close(0.7, 1e-6)
+    l1.g_b[0,1].should be_close(0.8, 1e-6)
+    l1.g_b[0,2].should be_close(0.9, 1e-6)
+
+    # gradient w.r.t input
+    grad_expected = [
+      0.1*0.7 + 0.2*0.8 + 0.3*0.9,
+      0.4*0.7 + 0.5*0.8 + 0.6*0.9,
+    ]
+    2.times do |j|
+      grad_in[0,j].should be_close(grad_expected[j], 1e-6)
+    end
+  end
+end

--- a/spec/network_matrix_spec.cr
+++ b/spec/network_matrix_spec.cr
@@ -32,27 +32,27 @@ describe SHAInet::Network do
     expected_output = [
       expected_hidden[0]*0.7 + expected_hidden[1]*0.8 + expected_hidden[2]*0.9 + 0.4,
     ]
-    out[0,0].should be_close(expected_output[0], 1e-6)
+    out[0, 0].should be_close(expected_output[0], 1e-6)
 
-    grad_out = mat_klass.ones(1,1)
+    grad_out = mat_klass.ones(1, 1)
     grad_in = net.backward(grad_out)
 
     # check gradients of last layer
-    l2.g_w[0,0].should be_close(expected_hidden[0], 1e-6)
-    l2.g_w[1,0].should be_close(expected_hidden[1], 1e-6)
-    l2.g_w[2,0].should be_close(expected_hidden[2], 1e-6)
-    l2.g_b[0,0].should be_close(1.0, 1e-6)
+    l2.g_w[0, 0].should be_close(expected_hidden[0], 1e-6)
+    l2.g_w[1, 0].should be_close(expected_hidden[1], 1e-6)
+    l2.g_w[2, 0].should be_close(expected_hidden[2], 1e-6)
+    l2.g_b[0, 0].should be_close(1.0, 1e-6)
 
     # gradients for first layer
-    l1.g_w[0,0].should be_close(1.0*0.7, 1e-6)
-    l1.g_w[0,1].should be_close(1.0*0.8, 1e-6)
-    l1.g_w[0,2].should be_close(1.0*0.9, 1e-6)
-    l1.g_w[1,0].should be_close(2.0*0.7, 1e-6)
-    l1.g_w[1,1].should be_close(2.0*0.8, 1e-6)
-    l1.g_w[1,2].should be_close(2.0*0.9, 1e-6)
-    l1.g_b[0,0].should be_close(0.7, 1e-6)
-    l1.g_b[0,1].should be_close(0.8, 1e-6)
-    l1.g_b[0,2].should be_close(0.9, 1e-6)
+    l1.g_w[0, 0].should be_close(1.0*0.7, 1e-6)
+    l1.g_w[0, 1].should be_close(1.0*0.8, 1e-6)
+    l1.g_w[0, 2].should be_close(1.0*0.9, 1e-6)
+    l1.g_w[1, 0].should be_close(2.0*0.7, 1e-6)
+    l1.g_w[1, 1].should be_close(2.0*0.8, 1e-6)
+    l1.g_w[1, 2].should be_close(2.0*0.9, 1e-6)
+    l1.g_b[0, 0].should be_close(0.7, 1e-6)
+    l1.g_b[0, 1].should be_close(0.8, 1e-6)
+    l1.g_b[0, 2].should be_close(0.9, 1e-6)
 
     # gradient w.r.t input
     grad_expected = [
@@ -60,7 +60,7 @@ describe SHAInet::Network do
       0.4*0.7 + 0.5*0.8 + 0.6*0.9,
     ]
     2.times do |j|
-      grad_in[0,j].should be_close(grad_expected[j], 1e-6)
+      grad_in[0, j].should be_close(grad_expected[j], 1e-6)
     end
   end
 end

--- a/src/shainet/basic/network.cr
+++ b/src/shainet/basic/network.cr
@@ -1,0 +1,34 @@
+require "./matrix_layer"
+require "../math/unified_matrix"
+
+module SHAInet
+  class Network
+    getter layers : Array(MatrixLayer)
+
+    def initialize
+      @layers = [] of MatrixLayer
+    end
+
+    def add_layer(in_size : Int32, out_size : Int32)
+      layer = MatrixLayer.new(in_size, out_size)
+      @layers << layer
+      layer
+    end
+
+    def forward(input : UnifiedMatrix::MatrixData) : UnifiedMatrix::MatrixData
+      result = input
+      @layers.each do |layer|
+        result = layer.forward(result)
+      end
+      result
+    end
+
+    def backward(grad : UnifiedMatrix::MatrixData) : UnifiedMatrix::MatrixData
+      g = grad
+      @layers.reverse_each do |layer|
+        g = layer.backward(g)
+      end
+      g
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement matrix-based `Network` with simple add_layer/forward/backward
- simplify transformer forward path in `network_run.cr`
- remove neuron bookkeeping from `network_setup.cr`
- add unit spec for matrix network

## Testing
- `crystal spec spec/network_matrix_spec.cr` *(fails: Stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_6863966d85c083318cf17868581fb0a4