### PR TITLE
Refactor network loops and storage

### DIFF
--- a/spec/legacy_network_spec.cr
+++ b/spec/legacy_network_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+describe SHAInet::LegacyNetwork do
+  it "delegates to the internal Network" do
+    net = SHAInet::LegacyNetwork.new
+    layer1 = net.add_layer(2, 3)
+    layer2 = net.add_layer(3, 1)
+
+    input = SHAInet::SimpleMatrix.from_a([[1.0, 2.0]])
+    out = net.forward(input)
+    out.rows.should eq 1
+    out.cols.should eq 1
+
+    grad_out = SHAInet::SimpleMatrix.ones(1, 1)
+    grad_in = net.backward(grad_out)
+    grad_in.rows.should eq 1
+    grad_in.cols.should eq 2
+  end
+end

--- a/src/shainet/basic/legacy_network.cr
+++ b/src/shainet/basic/legacy_network.cr
@@ -1,0 +1,11 @@
+module SHAInet
+  class LegacyNetwork
+    getter network : Network
+
+    def initialize
+      @network = Network.new
+    end
+
+    forward_missing_to @network
+  end
+end


### PR DESCRIPTION
## Summary
- streamline backpropagation using MatrixLayer APIs
- save/load network weights as matrices instead of neurons
- introduce `LegacyNetwork` wrapper
- test wrapper behavior

## Testing
- `crystal spec spec/load_save_spec.cr`
- `crystal spec spec/legacy_network_spec.cr`


------
https://chatgpt.com/codex/tasks/task_e_6863d01f8614833198e26a19e564ac96