### PR TITLE
Add CUDA softmax kernel fallback

### DIFF
--- a/spec/cuda_softmax_inplace_spec.cr
+++ b/spec/cuda_softmax_inplace_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+describe "CudaMatrix#softmax_rows!" do
+  it "matches CPU softmax" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+    cpu = SHAInet::SimpleMatrix.from_a([[0.5, 1.5, 2.5], [3.0, 0.0, -1.0]])
+    expected = SHAInet.softmax_rows(cpu)
+
+    gpu = SHAInet::GPUMemory.to_gpu(cpu).as(SHAInet::CudaMatrix)
+    gpu.softmax_rows!
+    gpu.sync_from_device!
+
+    expected.rows.times do |i|
+      expected.cols.times do |j|
+        gpu[i, j].should be_close(expected[i, j], 1e-6)
+      end
+    end
+  end
+end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -850,14 +850,22 @@ module SHAInet
         end
       end
 
-      # Fallback to existing implementation
+      # Try custom CUDA kernel before falling back to CPU
+      if CUDA.fully_available? && (dptr = self.device_ptr) && !dptr.null?
+        begin
+          self.sync_to_device!("softmax_kernel") unless device_dirty?
+          CUDA.softmax_rows(dptr, dptr, @rows, @cols)
+          mark_device_dirty!
+          return self
+        rescue e : Exception
+          Log.debug { "CUDA softmax kernel failed: #{e}, falling back to CPU" }
+        end
+      end
+
+      # CPU fallback implementation
       raise RuntimeError.new("GPU softmax requires valid device pointer") unless (dptr = self.device_ptr) && !dptr.null?
 
-      # Ensure self has up-to-date GPU data
-      self.sync_to_device!("softmax_activation") unless device_dirty?
-
-      # Use existing CUDA kernel or CPU fallback
-      # This would benefit from a custom CUDA softmax kernel
+      # Ensure self has up-to-date CPU data
       self.sync_from_device!("softmax_fallback")
       @rows.times do |i|
         # Compute softmax for each row


### PR DESCRIPTION
## Summary
- implement a simple CUDA kernel for row-wise softmax with numerical stability
- call the CUDA kernel from `CudaMatrix#softmax_rows!` before falling back to CPU
- add spec verifying GPU and CPU softmax results for in-place version

## Testing
- `crystal spec spec/cuda_softmax_inplace_spec.cr -Dwithout_network_data` *(fails: cannot find -lcudnn)*
- `crystal spec spec/cuda_softmax_dropout_spec.cr -Dwithout_network_data`

------
https://chatgpt.com/codex/tasks/task_e_686a68a1abcc8331b35c99bd42a5f7dd