### PR TITLE
Implement transpose caching for transformer layers

### DIFF
--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -85,6 +85,20 @@ module SHAInet
       result
     end
 
+    # Transpose the matrix into an existing destination matrix in-place.
+    # This avoids allocating a new matrix on each call.
+    def transpose_into!(dest : SimpleMatrix)
+      raise ArgumentError.new("size mismatch") unless dest.rows == @cols && dest.cols == @rows
+
+      @rows.times do |i|
+        @cols.times do |j|
+          dest[j, i] = self[i, j]
+        end
+      end
+
+      dest
+    end
+
     def to_a
       Array.new(@rows) do |i|
         Array.new(@cols) do |j|


### PR DESCRIPTION
## Summary
- add `transpose_into!` for CudaMatrix and SimpleMatrix
- cache transposed weight matrices in MultiHeadAttention
- cache transposed weight matrices in PositionWiseFF
- update caches when weights change
- use cached transposes during backward passes

## Testing
- `SHAINET_DISABLE_CUDA=1 crystal spec --order random` *(fails: cannot find -lcudnn)*

------
https://chatgpt.com/codex/tasks/task_e_686aeb1483508331a0be87e37c4c6b8b