### PR TITLE
Implement persistent GPU batch buffers

### DIFF
--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -81,6 +81,10 @@ module SHAInet
       @cached_expanded_grad = nil
       @cached_seq_len = 0
       @cached_d_model = 0
+
+      @batch_in_ws = nil
+      @batch_out_ws = nil
+      @batch_grad_ws = nil
     end
 
     # Create and populate a layer


### PR DESCRIPTION
## Summary
- add persistent GPU matrices to `StreamingData`
- keep batch workspace matrices across iterations in `Network`

## Testing
- `crystal tool format src/shainet/data/streaming_data.cr src/shainet/basic/network_run.cr src/shainet/basic/network_setup.cr`
- `crystal spec` *(fails: cannot find -lcudnn)*

------
https://chatgpt.com/codex/tasks/task_e_686b786c515883318da41e28348043cd