### PR TITLE
Add GPU data preload option

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -618,6 +618,9 @@ module SHAInet
       verify_net_before_train
 
       stream = data.is_a?(SHAInet::StreamingData) ? data : nil
+      if data.is_a?(SHAInet::TrainingData) && data.preload_gpu? && CUDA.fully_available?
+        data.preload_gpu!
+      end
       # Convert TrainingData to raw data array
       raw_data = if data.is_a?(SHAInet::TrainingData)
                    data.data
@@ -776,18 +779,21 @@ module SHAInet
       output_grad : SimpleMatrix | CudaMatrix | Nil = nil
 
       if CUDA.fully_available?
-        if @batch_in_ws.nil? || @batch_in_ws.not_nil!.rows != in_rows || @batch_in_ws.not_nil!.cols != in_cols
-          @batch_in_ws = CudaMatrix.new(in_rows, in_cols)
+        if !first_input.is_a?(CudaMatrix)
+          if @batch_in_ws.nil? || @batch_in_ws.not_nil!.rows != in_rows || @batch_in_ws.not_nil!.cols != in_cols
+            @batch_in_ws = CudaMatrix.new(in_rows, in_cols)
+          end
+          input_workspace = @batch_in_ws
         end
-        if @batch_out_ws.nil? || @batch_out_ws.not_nil!.rows != out_rows || @batch_out_ws.not_nil!.cols != out_cols
-          @batch_out_ws = CudaMatrix.new(out_rows, out_cols)
+        if !first_output.is_a?(CudaMatrix)
+          if @batch_out_ws.nil? || @batch_out_ws.not_nil!.rows != out_rows || @batch_out_ws.not_nil!.cols != out_cols
+            @batch_out_ws = CudaMatrix.new(out_rows, out_cols)
+          end
+          expected_workspace = @batch_out_ws
         end
         if @batch_grad_ws.nil? || @batch_grad_ws.not_nil!.rows != out_rows || @batch_grad_ws.not_nil!.cols != out_cols
           @batch_grad_ws = CudaMatrix.new(out_rows, out_cols)
         end
-
-        input_workspace = @batch_in_ws
-        expected_workspace = @batch_out_ws
         output_grad = @batch_grad_ws
       end
 
@@ -995,11 +1001,11 @@ module SHAInet
         GC.collect
 
         # Return workspace matrices used for this sample
-        if input_matrix.is_a?(CudaMatrix)
+        if input_matrix.is_a?(CudaMatrix) && input_workspace && input_matrix.object_id == input_workspace.object_id
           CudaMatrix.return_workspace(input_matrix)
         end
-        if expected_output.is_a?(CudaMatrix)
-          CudaMatrix.return_workspace(expected_output)
+        if expected_matrix.is_a?(CudaMatrix) && expected_workspace && expected_matrix.object_id == expected_workspace.object_id
+          CudaMatrix.return_workspace(expected_matrix)
         end
       end
 

--- a/src/shainet/data/training_data.cr
+++ b/src/shainet/data/training_data.cr
@@ -1,4 +1,60 @@
+require "../cuda"
+require "../math/cuda_matrix"
+require "../math/gpu_memory"
+
 module SHAInet
+  # TrainingData represents normalized datasets used for standard
+  # in-memory training. When `preload_gpu` is enabled and CUDA is
+  # available, the normalized inputs and outputs can be converted to
+  # `CudaMatrix` instances once up front to avoid per-sample CPU->GPU
+  # transfers during training.
   class TrainingData < Data
+    property? preload_gpu
+    @gpu_inputs : Array(CudaMatrix) = [] of CudaMatrix
+    @gpu_outputs : Array(CudaMatrix) = [] of CudaMatrix
+
+    def initialize(@inputs : Array(Array(Float64)), @outputs : Array(Array(Float64)), @preload_gpu : Bool = false)
+      super(@inputs, @outputs)
+    end
+
+    # Convert all normalized data to CudaMatrix and store it. This
+    # should be called after the data has been normalized.
+    def preload_gpu!
+      return unless CUDA.fully_available?
+      return if @gpu_inputs.size == @normalized_inputs.size && @gpu_outputs.size == @normalized_outputs.size
+
+      @gpu_inputs = Array(CudaMatrix).new(@normalized_inputs.size) do |idx|
+        row = @normalized_inputs[idx]
+        mat = CudaMatrix.new(1, row.size)
+        GPUMemory.to_gpu!(row, mat)
+        mat
+      end
+
+      @gpu_outputs = Array(CudaMatrix).new(@normalized_outputs.size) do |idx|
+        row = @normalized_outputs[idx]
+        mat = CudaMatrix.new(1, row.size)
+        GPUMemory.to_gpu!(row, mat)
+        mat
+      end
+      @preload_gpu = true
+    end
+
+    # Return training pairs either as arrays of Float64 or as GPU
+    # matrices when preloaded.
+    def data
+      if @preload_gpu && CUDA.fully_available?
+        arr = [] of Array(CudaMatrix)
+        @gpu_inputs.each_with_index do |input, i|
+          arr << [input, @gpu_outputs[i]]
+        end
+        arr
+      else
+        arr = [] of Array(Array(Float64))
+        @normalized_inputs.each_with_index do |_, i|
+          arr << [@normalized_inputs[i], @normalized_outputs[i]]
+        end
+        arr
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- allow `TrainingData` to preload normalized data to GPU
- add GPU preload call in `Network#train`
- skip GPU workspace for samples already on GPU

## Testing
- `crystal spec --order=random` *(fails: cannot find -lcudnn)*

------
https://chatgpt.com/codex/tasks/task_e_686b87df3e488331b3b3babe5056c208