### PR TITLE
Add CPU-only build option with CUDA stubs

### DIFF
--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -1,6 +1,45 @@
 require "log"
-require "./shainet/**"
+
+{% if flag?(:enable_cuda) %}
+require "./shainet/cuda"
 require "./shainet/cudnn"
+{% else %}
+require "./shainet/cuda_stub"
+{% end %}
+
+require "./shainet/autograd/tensor"
+require "./shainet/basic/exceptions"
+require "./shainet/basic/matrix_layer"
+require "./shainet/basic/network_run"
+require "./shainet/basic/network_setup"
+require "./shainet/concurrency/concurrent_tokenizer"
+require "./shainet/data/data"
+require "./shainet/data/json_data"
+require "./shainet/data/streaming_data"
+require "./shainet/data/test_data"
+require "./shainet/data/training_data"
+require "./shainet/math/batch_processor"
+require "./shainet/math/cuda_matrix"
+require "./shainet/math/cuda_matrix_ext"
+require "./shainet/math/cuda_tensor_matrix"
+require "./shainet/math/functions"
+require "./shainet/math/gpu_memory"
+require "./shainet/math/random_normal"
+require "./shainet/math/simple_matrix"
+require "./shainet/math/tensor_matrix"
+require "./shainet/math/unified_matrix"
+require "./shainet/pytorch_import"
+require "./shainet/text/bpe_tokenizer"
+require "./shainet/text/embedding_layer"
+require "./shainet/text/tokenizer"
+require "./shainet/transformer/dropout"
+require "./shainet/transformer/ext"
+require "./shainet/transformer/layer_norm"
+require "./shainet/transformer/multi_head_attention"
+require "./shainet/transformer/positional_encoding"
+require "./shainet/transformer/positionwise_ff"
+require "./shainet/transformer/transformer_block"
+require "./shainet/version"
 
 module SHAInet
   Log = ::Log.for(self)
@@ -15,7 +54,7 @@ module SHAInet
     "trace" => ::Log::Severity::Trace,
   }
 
-  log_level = (ENV["LOG_LEVEL"]? || "info") # Default to info level if not set
+  log_level = (ENV["LOG_LEVEL"]? || "info")
 
   ::Log.setup(lvl[log_level.downcase])
 end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1,6 +1,11 @@
 require "log"
 require "json"
+{% if flag?(:enable_cuda) %}
 require "../cuda"
+require "../cudnn"
+{% else %}
+require "../cuda_stub"
+{% end %}
 require "../math/simple_matrix"
 require "../math/cuda_matrix"
 

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -1,0 +1,234 @@
+module SHAInet
+  module CUDA
+    extend self
+    Log = ::Log.for(self)
+
+    enum MemcpyKind
+      HostToHost = 0
+      HostToDevice = 1
+      DeviceToHost = 2
+      DeviceToDevice = 3
+    end
+
+    enum Operation
+      N = 0
+      T = 1
+    end
+
+    lib LibCUBLAS
+      type Handle = Void*
+    end
+
+    def available? : Bool
+      false
+    end
+
+    def fully_available? : Bool
+      false
+    end
+
+    def version
+      nil
+    end
+
+    def cudnn_available? : Bool
+      false
+    end
+
+    def kernels_available? : Bool
+      false
+    end
+
+    def malloc(*args) : Int32
+      raise "CUDA disabled"
+    end
+
+    def free(*args)
+    end
+
+    def memcpy(*args)
+    end
+
+    def copy_device_to_device(*args)
+    end
+
+    def malloc_host(*args)
+      raise "CUDA disabled"
+    end
+
+    def free_host(*args)
+    end
+
+    def create_handle(*args)
+      raise "CUDA disabled"
+    end
+
+    def destroy_handle(*args)
+    end
+
+    def cleanup_handles(*args)
+    end
+
+    def gemm(*args)
+    end
+
+    def gemm_accumulate(*args)
+    end
+
+    def geam(*args)
+    end
+
+    def scal(*args)
+    end
+
+    def ger(*args)
+    end
+
+    def dot(*args)
+      0.0
+    end
+
+    def axpy(*args)
+    end
+
+    def softmax_rows(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def dropout(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def gather_rows(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def slice_cols(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def set_cols(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def row_mean_var(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def layer_norm(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def layer_norm_backward(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def sum_cols(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def mul_row_vector(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def transpose(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def sigmoid_forward(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def apply_gradient(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def accumulate_bias_grad(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def zero_matrix(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def element_div(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def relu(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def add_bias(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def row_sum(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def count_token_pairs(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def cross_entropy_loss_gradient(*args) : Int32
+      raise "CUDA kernels not available"
+    end
+
+    def dropout(*args) : Int32
+      raise "CUDA kernels not available"
+    end
+
+    def relu_backward(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def softmax_backward(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def element_log(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def mse_cost_gradient(*args)
+      raise "CUDA kernels not available"
+    end
+  end
+
+  module CUDNN
+    extend self
+
+    def available? : Bool
+      false
+    end
+
+    def add_bias!(*args); raise CudnnError.new("cuDNN not available"); end
+    def relu_forward(*args); raise CudnnError.new("cuDNN not available"); end
+    def relu_backward(*args); raise CudnnError.new("cuDNN not available"); end
+    def sigmoid_forward!(*args); raise CudnnError.new("cuDNN not available"); end
+    def tanh_forward!(*args); raise CudnnError.new("cuDNN not available"); end
+    def softmax_rows(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_add!(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_multiply!(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_mul!(*args); raise CudnnError.new("cuDNN not available"); end
+    def dropout_forward!(*args); raise CudnnError.new("cuDNN not available"); end
+    def softmax_cross_entropy_loss_and_gradient(*args); raise CudnnError.new("cuDNN not available"); end
+    def cross_entropy_loss_gradient(*args); raise CudnnError.new("cuDNN not available"); end
+    def cross_entropy_loss_and_gradient(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_log!(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_subtract!(*args); raise CudnnError.new("cuDNN not available"); end
+    def element_addition!(*args); raise CudnnError.new("cuDNN not available"); end
+
+    class CudnnError < Exception
+    end
+
+    def check_status(*args)
+      raise CudnnError.new("cuDNN not available")
+    end
+
+    def handle
+      raise CudnnError.new("cuDNN not available")
+    end
+  end
+end

--- a/src/shainet/data/training_data.cr
+++ b/src/shainet/data/training_data.cr
@@ -1,4 +1,8 @@
+{% if flag?(:enable_cuda) %}
 require "../cuda"
+{% else %}
+require "../cuda_stub"
+{% end %}
 require "../math/cuda_matrix"
 require "../math/gpu_memory"
 

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1,6 +1,10 @@
 require "./simple_matrix"
+{% if flag?(:enable_cuda) %}
 require "../cuda"
 require "../cudnn"
+{% else %}
+require "../cuda_stub"
+{% end %}
 
 module SHAInet
   # Basic GPU matrix wrapper. Allocates device memory when CUDA is

--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -1,4 +1,8 @@
+{% if flag?(:enable_cuda) %}
 require "../cuda"
+{% else %}
+require "../cuda_stub"
+{% end %}
 
 module SHAInet
   # GPU Memory Manager - helps minimize CPU-GPU transfers

--- a/src/shainet/text/tokenizer.cr
+++ b/src/shainet/text/tokenizer.cr
@@ -1,4 +1,8 @@
+{% if flag?(:enable_cuda) %}
 require "../cuda"
+{% else %}
+require "../cuda_stub"
+{% end %}
 require "../math/simple_matrix"
 require "../math/cuda_matrix"
 


### PR DESCRIPTION
## Summary
- allow compilation without CUDA/CuDNN by providing `cuda_stub`
- gate CUDA requires behind `enable_cuda` flag and update dependent files
- specs now run even when GPU libraries are missing

## Testing
- `crystal spec --no-color` *(fails: 101 examples, 10 failures, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b9884e9c08331b69410fff816c734