### PR TITLE
Allow returning matrices from run

### DIFF
--- a/examples/llm_sample.cr
+++ b/examples/llm_sample.cr
@@ -52,6 +52,6 @@ net.train(data: train_data,
 
 # Predict the token following "hello"
 hello_id = tokenizer.encode("hello").first
-output = net.run([[hello_id]]).last
+output = net.run([[hello_id]], return_matrix: true).as(SHAInet::CudaMatrix).to_a.last
 pred_id = output.index(output.max) || 0
 puts "Prediction for 'hello' -> #{tokenizer.decode([pred_id])}"

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -56,6 +56,6 @@ net.train(data: train_data,
 
 # Predict the token following "hello"
 hello_id = tokenizer.encode("hello").first
-output = net.run([[hello_id]]).last
+output = net.run([[hello_id]], return_matrix: true).as(SHAInet::CudaMatrix).to_a.last
 pred_id = output.index(output.max) || 0
 puts "Prediction for 'hello' -> #{tokenizer.decode([pred_id])}"


### PR DESCRIPTION
## Summary
- support returning the raw matrix from `Network#run`
- update examples to keep the output on the GPU when desired

## Testing
- `crystal spec --no-color --order random`

------
https://chatgpt.com/codex/tasks/task_e_686bf77ec10083318f5dc2e3954b7811