### PR TITLE
Optimize MHA backward with preallocated slices

### DIFF
--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -130,14 +130,21 @@ module SHAInet
       self
     end
 
+    # Slice a range of columns into the provided destination matrix.
+    def slice_cols_into!(dest : SimpleMatrix, start_col : Int32, length : Int32)
+      raise ArgumentError.new("size mismatch") unless dest.rows == @rows && dest.cols == length
+      @rows.times do |i|
+        length.times do |j|
+          dest[i, j] = self[i, start_col + j]
+        end
+      end
+      dest
+    end
+
     # Slice a range of columns from the matrix
     def slice_cols(start_col : Int32, length : Int32)
       result = SimpleMatrix.new(@rows, length)
-      @rows.times do |i|
-        length.times do |j|
-          result[i, j] = self[i, start_col + j]
-        end
-      end
+      slice_cols_into!(result, start_col, length)
       result
     end
 


### PR DESCRIPTION
## Summary
- add `slice_cols_into!` for `CudaMatrix` and `SimpleMatrix`
- update `slice_cols` to use the in-place version
- allocate per-head `d_concat` slice workspaces in `MultiHeadAttention`
- use these workspaces during backward pass

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686cb27ccfe88331b7ba114d9f908326