### PR TITLE
Add CUDA softmax cross entropy label kernel

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -175,6 +175,10 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def softmax_cross_entropy_label(*args) : Int32
+      raise "CUDA kernels not available"
+    end
+
     def dropout(*args) : Int32
       raise "CUDA kernels not available"
     end


### PR DESCRIPTION
## Summary
- add loader variable for `softmax_cross_entropy_label` in `cuda.cr`
- implement `CUDA.softmax_cross_entropy_label` using dynamic loading
- provide stub for the new method when CUDA kernels are unavailable

## Testing
- `shards install`
- `crystal spec -v`


------
https://chatgpt.com/codex/tasks/task_e_686ced6faa34833192a78aca83eb32aa