### PR TITLE
Improve GPU label cross-entropy path

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -251,6 +251,10 @@ module SHAInet
       raise CudnnError.new("cuDNN not available")
     end
 
+    def softmax_cross_entropy_label_loss_and_gradient(*args)
+      raise CudnnError.new("cuDNN not available")
+    end
+
     def cross_entropy_loss_gradient(*args)
       raise CudnnError.new("cuDNN not available")
     end


### PR DESCRIPTION
## Summary
- avoid converting label vectors to one-hot when CUDA and cuDNN are available
- support label-based softmax cross entropy in `process_batch`
- gracefully fall back to CPU when GPU is unavailable
- add stub for new cuDNN helper when CUDA is disabled

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_686cf3f5e110833195330ae8082e8e0c