### PR TITLE
Add GPU parity test for label cross entropy

### DIFF
--- a/spec/softmax_cross_entropy_label_cuda_spec.cr
+++ b/spec/softmax_cross_entropy_label_cuda_spec.cr
@@ -1,5 +1,10 @@
 require "./spec_helper"
 
+# Verify parity between the CPU implementation of softmax cross-entropy with
+# label indices and the optimized CUDA kernel. The test computes a reference
+# loss and gradient on the CPU and ensures the GPU API returns nearly identical
+# results.
+
 private def cpu_softmax_cross_entropy_label(logits : SHAInet::SimpleMatrix, labels : Array(Int32))
   rows = logits.rows
   cols = logits.cols


### PR DESCRIPTION
## Summary
- add clarifying comment to the new CUDA softmax cross-entropy with labels spec

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686cf8215bf88331a97c03971440ec63