### PR TITLE
Add in-place dropout for transformer

### DIFF
--- a/spec/transformer_dropout_spec.cr
+++ b/spec/transformer_dropout_spec.cr
@@ -18,4 +18,18 @@ describe SHAInet::TransformerDropout do
     average = total_ratio / runs
     (average).should be_close(0.30, 0.05)
   end
+
+  it "operates in-place on SimpleMatrix" do
+    mat = SHAInet::SimpleMatrix.ones(4, 4)
+    SHAInet::TransformerDropout.apply!(mat, 100)
+
+    zero_count = 0
+    mat.rows.times do |i|
+      mat.cols.times do |j|
+        zero_count += 1 if mat[i, j] == 0.0
+      end
+    end
+
+    zero_count.should eq(16)
+  end
 end

--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -201,6 +201,19 @@ module SHAInet
       self
     end
 
+    # Apply dropout in-place using the given probability in the range 0.0..1.0.
+    def dropout!(prob : Float64)
+      raise ArgumentError.new("prob must be between 0 and 1") unless 0.0 <= prob && prob <= 1.0
+
+      @rows.times do |i|
+        @cols.times do |j|
+          self[i, j] = Random.rand < prob ? 0.0 : self[i, j]
+        end
+      end
+
+      self
+    end
+
     # Multiply each column by the corresponding value in a row vector in-place.
     def mul_row_vector!(vec : SimpleMatrix)
       raise ArgumentError.new("vector size mismatch") unless vec.rows == 1 && vec.cols == @cols

--- a/src/shainet/transformer/dropout.cr
+++ b/src/shainet/transformer/dropout.cr
@@ -10,5 +10,18 @@ module SHAInet
     def self.apply(matrix : CudaMatrix, drop_percent : Int32)
       SHAInet.dropout(matrix, drop_percent)
     end
+
+    # Applies dropout to the given matrix in-place and returns it. `drop_percent`
+    # should be between 0 and 100.
+    def self.apply!(matrix : SimpleMatrix, drop_percent : Int32)
+      raise ArgumentError.new("drop_percent must be between 0 and 100") unless 0 <= drop_percent && drop_percent <= 100
+      matrix.dropout!(drop_percent.to_f / 100.0)
+    end
+
+    # Applies dropout to the given CUDA matrix in-place and returns it.
+    def self.apply!(matrix : CudaMatrix, drop_percent : Int32)
+      raise ArgumentError.new("drop_percent must be between 0 and 100") unless 0 <= drop_percent && drop_percent <= 100
+      matrix.dropout!(drop_percent.to_f / 100.0)
+    end
   end
 end

--- a/src/shainet/transformer/transformer_block.cr
+++ b/src/shainet/transformer/transformer_block.cr
@@ -57,11 +57,11 @@ module SHAInet
               end
 
       attn = @mha.forward(input, mask)
-      attn = TransformerDropout.apply(attn, @drop_percent) if @drop_percent > 0
+      TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
       attn = attn + input
       normed = @norm1.forward(attn).as(CudaMatrix)
       ff = @ffn.forward(normed)
-      ff = TransformerDropout.apply(ff, @drop_percent) if @drop_percent > 0
+      TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
       ff = ff + normed
       @norm2.forward(ff).as(CudaMatrix)
     end
@@ -87,11 +87,11 @@ module SHAInet
               end
 
       attn = @mha.forward(input, mask)
-      attn = TransformerDropout.apply(attn, @drop_percent) if @drop_percent > 0
+      TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
       attn = attn + input
       normed = @norm1.forward(attn).as(SimpleMatrix)
       ff = @ffn.forward(normed)
-      ff = TransformerDropout.apply(ff, @drop_percent) if @drop_percent > 0
+      TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
       ff = ff + normed
       final_result = @norm2.forward(ff)
       final_result.as(SimpleMatrix)


### PR DESCRIPTION
## Summary
- implement `TransformerDropout.apply!` for CPU and GPU matrices
- add optional `SimpleMatrix#dropout!` helper
- use in-place dropout inside `TransformerBlock`
- test that in-place dropout works

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686d0b6242d88331bddf966700ac2cc8