### PR TITLE
Implement GPU constant fill kernel

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -151,6 +151,10 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def fill_matrix(*args)
+      raise "CUDA kernels not available"
+    end
+
     def element_div(*args)
       raise "CUDA kernels not available"
     end

--- a/src/shainet/native/cuda_kernels.cu
+++ b/src/shainet/native/cuda_kernels.cu
@@ -394,6 +394,24 @@ void zero_matrix(double* matrix, int size) {
     }
 }
 
+__global__ void fill_matrix_kernel(double* matrix, double value, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= size) return;
+
+    matrix[idx] = value;
+}
+
+void fill_matrix(double* matrix, double value, int size) {
+    int threads_per_block = 256;
+    int blocks = (size + threads_per_block - 1) / threads_per_block;
+
+    fill_matrix_kernel<<<blocks, threads_per_block>>>(matrix, value, size);
+    cudaError_t err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+        printf("CUDA Error in fill_matrix: %s\n", cudaGetErrorString(err));
+    }
+}
+
 __global__ void element_div_kernel(double* out, const double* a, const double* b, int size){
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if(idx >= size) return;


### PR DESCRIPTION
## Summary
- add a CUDA kernel to fill device buffers with constants
- provide Crystal binding to the new fill_matrix kernel
- update CudaMatrix#fill! to use the kernel when CUDA is available
- keep zero fill specialization and CPU fallback

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_686d371fbe6483319660550736e203c8