### PR TITLE
Use CUDA mem info for GPU limit

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -59,6 +59,14 @@ module SHAInet
     def free_host(*args)
     end
 
+    def memory_info
+      nil
+    end
+
+    def total_memory
+      nil
+    end
+
     def create_handle(*args)
       raise "CUDA disabled"
     end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -21,7 +21,7 @@ module SHAInet
     # Global GPU memory tracking
     @@total_gpu_memory_allocated = 0_u64
     @@active_matrices = 0
-    @@max_gpu_memory = 16_000_000_000_u64 # 16GB limit (use most of available GPU memory)
+    @@max_gpu_memory = (CUDA.total_memory || 16_000_000_000_u64) # Use available GPU memory when possible
     @@allocation_attempts = 0
     @@allocation_failures = 0
 


### PR DESCRIPTION
## Summary
- expose `cudaMemGetInfo` in CUDA bindings
- add `memory_info` and `total_memory` helpers
- update CPU fallback to provide stub methods
- use CUDA total memory to set `CudaMatrix` GPU limit

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686d4fe57ce08331b696e76c3d0214f2