### PR TITLE
Add attention mask utilities

### DIFF
--- a/spec/transformer_mask_utils_spec.cr
+++ b/spec/transformer_mask_utils_spec.cr
@@ -1,0 +1,30 @@
+require "./spec_helper"
+
+describe SHAInet::TransformerMaskUtils do
+  it "creates a causal mask" do
+    mask = SHAInet::TransformerMaskUtils.causal_mask(3)
+    expected = [
+      [0.0, 0.0, 0.0],
+      [-1e9, 0.0, 0.0],
+      [-1e9, -1e9, 0.0],
+    ]
+    mask.rows.times do |i|
+      mask.cols.times do |j|
+        mask[i, j].should eq(expected[i][j])
+      end
+    end
+  end
+
+  it "creates a padding mask" do
+    mask = SHAInet::TransformerMaskUtils.padding_mask([1, 3])
+    expected = [
+      [0.0, -1e9, -1e9],
+      [0.0, 0.0, 0.0],
+    ]
+    mask.rows.times do |i|
+      mask.cols.times do |j|
+        mask[i, j].should eq(expected[i][j])
+      end
+    end
+  end
+end

--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -37,6 +37,7 @@ require "./shainet/transformer/layer_norm"
 require "./shainet/transformer/multi_head_attention"
 require "./shainet/transformer/positional_encoding"
 require "./shainet/transformer/positionwise_ff"
+require "./shainet/transformer/mask_utils"
 require "./shainet/transformer/transformer_block"
 require "./shainet/version"
 

--- a/src/shainet/transformer/mask_utils.cr
+++ b/src/shainet/transformer/mask_utils.cr
@@ -1,0 +1,32 @@
+module SHAInet
+  # Utility methods for building attention masks for Transformer modules.
+  module TransformerMaskUtils
+    # Returns a lower triangular causal mask of shape (size, size).
+    # Positions below the diagonal are set to -1e9 while others are 0.
+    def self.causal_mask(size : Int32) : SimpleMatrix
+      mask = SimpleMatrix.zeros(size, size)
+      size.times do |i|
+        i.times do |j|
+          mask[i, j] = -1e9
+        end
+      end
+      mask
+    end
+
+    # Builds a padding mask for variable-length sequences.
+    # `lengths` contains the valid length for each batch entry. Positions
+    # beyond the length are filled with -1e9.
+    def self.padding_mask(lengths : Array(Int32)) : SimpleMatrix
+      batch = lengths.size
+      max_len = lengths.max
+      mask = SimpleMatrix.zeros(batch, max_len)
+      batch.times do |i|
+        len = lengths[i]
+        len.upto(max_len - 1) do |j|
+          mask[i, j] = -1e9
+        end
+      end
+      mask
+    end
+  end
+end

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -1,5 +1,7 @@
 module SHAInet
   class MultiHeadAttention
+    # Multi-head scaled dot-product attention layer. Use `TransformerMaskUtils.causal_mask` or `TransformerMaskUtils.padding_mask`
+    # to construct the optional attention mask passed to `forward`.
     getter num_heads, d_model, head_dim
     @head_dim : Int32
     @w_q : SimpleMatrix | CudaMatrix

--- a/src/shainet/transformer/transformer_block.cr
+++ b/src/shainet/transformer/transformer_block.cr
@@ -4,6 +4,7 @@ module SHAInet
   # TransformerBlock implements multi-head self-attention followed by a
   # position-wise feed forward network. LayerNorm and dropout are applied
   # with residual connections around each sub layer.
+  # Masks for the attention layer can be generated with TransformerMaskUtils.causal_mask or TransformerMaskUtils.padding_mask.
   class TransformerBlock < MatrixLayer
     getter mha : MultiHeadAttention
     getter ffn : PositionWiseFF


### PR DESCRIPTION
## Summary
- add `TransformerMaskUtils` with helpers for building causal and padding masks
- reference mask helpers in `MultiHeadAttention` and `TransformerBlock`
- wire mask utilities into `shainet.cr`
- test new utilities

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686d646c5c408331b56782077337e0a5