### PR TITLE
Add residual connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SHAInet (Super Human Artificial Intelligence Network) is a neural network librar
 - Multiple layer types and activation functions
 - Various training algorithms (SGD, Adam, iRprop+, etc.)
 - Streaming data support for large datasets
+- Residual skip connections between layers
 - PyTorch and HuggingFace model import
 - Transformer and modern NLP support
 

--- a/spec/residual_network_spec.cr
+++ b/spec/residual_network_spec.cr
@@ -1,0 +1,32 @@
+require "./spec_helper"
+
+describe "Residual connections" do
+  it "trains a small residual network" do
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2, SHAInet.sigmoid)
+    net.add_layer(:hidden, 1, SHAInet.sigmoid)
+    net.add_layer(:output, 1, SHAInet.sigmoid)
+    net.fully_connect
+    net.add_residual(0, 1)
+
+    training_data = [
+      [[0.0, 0.0], [0.0]],
+      [[0.0, 1.0], [1.0]],
+      [[1.0, 0.0], [1.0]],
+      [[1.0, 1.0], [0.0]],
+    ]
+
+    net.train(
+      data: training_data,
+      training_type: :adam,
+      cost_function: :mse,
+      epochs: 10,
+      mini_batch_size: 2,
+      log_each: 5,
+      show_slice: true
+    )
+
+    result = net.run([0.0, 1.0])
+    result.size.should eq(1)
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -149,7 +149,8 @@ module SHAInet
         matrix.as(CudaMatrix)
       else
         # Standard matrix processing for non-transformer networks
-        @hidden_layers.each do |l|
+        outputs = [] of CudaMatrix | SimpleMatrix
+        @hidden_layers.each_with_index do |l, idx|
           case l
           when EmbeddingLayer
             # Ensure embedding layer is on GPU for GPU path
@@ -162,11 +163,27 @@ module SHAInet
             l.to_gpu! if l.responds_to?(:to_gpu!)
             matrix = l.forward(matrix)
           end
+          if !@residual_edges.empty?
+            if list = @residual_edges[idx]?
+              list.each do |src|
+                add_matrix!(matrix, outputs[src])
+              end
+            end
+            outputs << matrix
+          end
         end
         out_layer = @output_layers.last
         # Ensure output layer is on GPU for GPU path
         out_layer.to_gpu!
         matrix = out_layer.forward(matrix)
+        if !@residual_edges.empty?
+          if list = @residual_edges[@hidden_layers.size]?
+            list.each do |src|
+              add_matrix!(matrix, outputs[src])
+            end
+          end
+          outputs << matrix
+        end
         matrix.as(CudaMatrix)
       end
     rescue e : Exception
@@ -222,7 +239,8 @@ module SHAInet
         matrix.as(SimpleMatrix)
       else
         # Standard matrix processing for non-transformer networks
-        @hidden_layers.each do |l|
+        outputs = [] of CudaMatrix | SimpleMatrix
+        @hidden_layers.each_with_index do |l, idx|
           case l
           when EmbeddingLayer
             raise NeuralNetRunError.new("Embedding input mismatch") unless matrix.cols == 1
@@ -231,9 +249,21 @@ module SHAInet
           else
             matrix = l.forward(matrix)
           end
+          if list = @residual_edges[idx]?
+            list.each do |src|
+              add_matrix!(matrix, outputs[src])
+            end
+          end
+          outputs << matrix
         end
         out_layer = @output_layers.last
         matrix = out_layer.forward(matrix)
+        if list = @residual_edges[@hidden_layers.size]?
+          list.each do |src|
+            add_matrix!(matrix, outputs[src])
+          end
+        end
+        outputs << matrix
         matrix.as(SimpleMatrix)
       end
     rescue e : Exception
@@ -1049,6 +1079,13 @@ module SHAInet
           batch_error += sample_error
 
           # grad_matrix is already GPU-compatible and reused across samples
+          extras = Hash(Int32, CudaMatrix | SimpleMatrix).new
+          if list = @residual_edges[@hidden_layers.size]?
+            list.each do |src|
+              extras[src] = clone_matrix(grad_matrix)
+            end
+          end
+
           grad = output_layer.backward(grad_matrix)
 
           # Handle transformer layers backward pass with proper gradient reshaping
@@ -1112,7 +1149,22 @@ module SHAInet
             end
           end
 
-          @hidden_layers.reverse_each do |layer|
+          (@hidden_layers.size - 1).downto(0) do |idx|
+            if extra = extras[idx]?
+              add_matrix!(grad, extra)
+            end
+
+            if list = @residual_edges[idx]?
+              list.each do |src|
+                if extras[src]?
+                  add_matrix!(extras[src], grad)
+                else
+                  extras[src] = clone_matrix(grad)
+                end
+              end
+            end
+
+            layer = @hidden_layers[idx]
             if layer.is_a?(MatrixLayer)
               grad = layer.backward(grad)
             elsif layer.is_a?(EmbeddingLayer)
@@ -1554,6 +1606,20 @@ module SHAInet
       end
 
       sample_error
+    end
+
+    private def add_matrix!(dest : CudaMatrix | SimpleMatrix, src : CudaMatrix | SimpleMatrix)
+      if dest.is_a?(CudaMatrix)
+        other = src.is_a?(CudaMatrix) ? src.as(CudaMatrix) : src.as(SimpleMatrix).to_cuda
+        dest.as(CudaMatrix).add!(other)
+      else
+        other = src.is_a?(SimpleMatrix) ? src.as(SimpleMatrix) : src.as(CudaMatrix).to_simple
+        dest.as(SimpleMatrix).add!(other)
+      end
+    end
+
+    private def clone_matrix(mat : CudaMatrix | SimpleMatrix)
+      mat.is_a?(CudaMatrix) ? mat.as(CudaMatrix).clone : mat.as(SimpleMatrix).clone
     end
   end
 end


### PR DESCRIPTION
## Summary
- store residual edges for networks and expose `add_residual`
- support residual edges in matrix forward and backward passes
- add basic residual-network spec
- document residual connection usage in README

## Testing
- `bin/ameba || true`
- `crystal tool format src/shainet/basic/network_setup.cr src/shainet/basic/network_run.cr spec/residual_network_spec.cr`
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_686d64f5f4b08331bf1e3b3e9023c01b