### PR TITLE
Add pre-norm option to TransformerBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ net.train(
 ## Advanced
 
 - See `examples/babylm_transformer.cr` for a transformer language model.
+- Transformer blocks can use pre-layer normalization via `pre_norm: true` when added with `net.add_layer(:transformer, d_model, pre_norm: true)`.
 - Import PyTorch models with `net.load_from_pt("model.pt")`.
 - Import HuggingFace GPT weights directly from `pytorch_model.bin`.
 

--- a/spec/transformer_block_spec.cr
+++ b/spec/transformer_block_spec.cr
@@ -7,4 +7,21 @@ describe SHAInet::Network do
     net.add_layer(:transformer, 2, blocks: 3)
     net.transformer_layers.size.should eq(3)
   end
+
+  it "runs transformer block in post and pre norm modes" do
+    input = SHAInet::SimpleMatrix.ones(2, 2)
+
+    post = SHAInet::TransformerBlock.new(2, 1, 4)
+    pre = SHAInet::TransformerBlock.new(2, 1, 4, 0, true)
+
+    out_post = post.forward(input)
+    out_pre = pre.forward(input)
+
+    out_post.rows.should eq(2)
+    out_pre.rows.should eq(2)
+
+    dout = SHAInet::SimpleMatrix.ones(2, 2)
+    post.backward(dout)
+    pre.backward(dout)
+  end
 end

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -91,10 +91,10 @@ module SHAInet
     # l_type is: :input, :hidden or :output
     # l_size = size of the layer
     # n_type = advanced option for layer types
-    def add_layer(l_type : Symbol | String, l_size : Int32, activation_function : ActivationFunction = SHAInet.sigmoid, num_heads : Int32 = 1, ff_hidden : Int32 = l_size*4, drop_percent : Int32 = 0, blocks : Int32 = 1, *, vocab_size : Int32 = 0)
+    def add_layer(l_type : Symbol | String, l_size : Int32, activation_function : ActivationFunction = SHAInet.sigmoid, num_heads : Int32 = 1, ff_hidden : Int32 = l_size*4, drop_percent : Int32 = 0, pre_norm : Bool = false, blocks : Int32 = 1, *, vocab_size : Int32 = 0)
       if l_type.to_s == "transformer" && blocks > 1
         blocks.times do
-          add_layer(l_type, l_size, activation_function, num_heads, ff_hidden, drop_percent, 1)
+          add_layer(l_type, l_size, activation_function, num_heads, ff_hidden, drop_percent, pre_norm, 1)
         end
         return
       end
@@ -103,7 +103,7 @@ module SHAInet
                 raise NeuralNetRunError.new("vocab_size required for embedding layer") if vocab_size <= 0
                 EmbeddingLayer.new(vocab_size, l_size, activation_function)
               when "transformer"
-                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent)
+                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent, pre_norm)
               else
                 # Use MatrixLayer for regular feedforward layers - it has proper GPU support and gradient computation
                 # Note: MatrixLayer will be properly connected with correct input size in connect_ltl

--- a/src/shainet/transformer/transformer_block.cr
+++ b/src/shainet/transformer/transformer_block.cr
@@ -9,11 +9,12 @@ module SHAInet
     getter ffn : PositionWiseFF
     getter norm1 : LayerNorm
     getter norm2 : LayerNorm
+    getter pre_norm : Bool
     property positional_encoding : SimpleMatrix | CudaMatrix | Nil
     property drop_percent : Int32
 
     def initialize(d_model : Int32, num_heads : Int32, ff_hidden : Int32,
-                   drop_percent : Int32 = 0)
+                   drop_percent : Int32 = 0, pre_norm : Bool = false)
       super(d_model, SHAInet.none)
       @mha = MultiHeadAttention.new(d_model, num_heads)
       @ffn = PositionWiseFF.new(d_model, ff_hidden)
@@ -21,6 +22,7 @@ module SHAInet
       @norm2 = LayerNorm.new(d_model)
       @positional_encoding = nil
       @drop_percent = drop_percent
+      @pre_norm = pre_norm
     end
 
     # Convert all internal matrices to GPU
@@ -56,14 +58,26 @@ module SHAInet
                 x
               end
 
-      attn = @mha.forward(input, mask)
-      TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
-      attn.add!(input)
-      normed = @norm1.forward(attn).as(CudaMatrix)
-      ff = @ffn.forward(normed)
-      TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
-      ff.add!(normed)
-      @norm2.forward(ff).as(CudaMatrix)
+      if @pre_norm
+        normed_in = @norm1.forward(input).as(CudaMatrix)
+        attn = @mha.forward(normed_in, mask)
+        TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
+        attn.add!(input)
+        normed_ff = @norm2.forward(attn).as(CudaMatrix)
+        ff = @ffn.forward(normed_ff)
+        TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
+        ff.add!(normed_ff)
+        ff.as(CudaMatrix)
+      else
+        attn = @mha.forward(input, mask)
+        TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
+        attn.add!(input)
+        normed = @norm1.forward(attn).as(CudaMatrix)
+        ff = @ffn.forward(normed)
+        TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
+        ff.add!(normed)
+        @norm2.forward(ff).as(CudaMatrix)
+      end
     end
 
     # CPU path - all SimpleMatrix operations
@@ -86,37 +100,69 @@ module SHAInet
                 x
               end
 
-      attn = @mha.forward(input, mask)
-      TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
-      attn.add!(input)
-      normed = @norm1.forward(attn).as(SimpleMatrix)
-      ff = @ffn.forward(normed)
-      TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
-      ff.add!(normed)
-      final_result = @norm2.forward(ff)
-      final_result.as(SimpleMatrix)
+      if @pre_norm
+        normed_in = @norm1.forward(input).as(SimpleMatrix)
+        attn = @mha.forward(normed_in, mask)
+        TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
+        attn.add!(input)
+        normed_ff = @norm2.forward(attn).as(SimpleMatrix)
+        ff = @ffn.forward(normed_ff)
+        TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
+        ff.add!(normed_ff)
+        ff.as(SimpleMatrix)
+      else
+        attn = @mha.forward(input, mask)
+        TransformerDropout.apply!(attn, @drop_percent) if @drop_percent > 0
+        attn.add!(input)
+        normed = @norm1.forward(attn).as(SimpleMatrix)
+        ff = @ffn.forward(normed)
+        TransformerDropout.apply!(ff, @drop_percent) if @drop_percent > 0
+        ff.add!(normed)
+        final_result = @norm2.forward(ff)
+        final_result.as(SimpleMatrix)
+      end
     end
 
     # GPU path backward - all CudaMatrix operations
     def backward(d_out : CudaMatrix) : CudaMatrix
-      d_norm2 = @norm2.backward(d_out)
-      d_ff = @ffn.backward(d_norm2).as(CudaMatrix)
-      d_ff.add!(d_norm2.as(CudaMatrix))
-      d_norm1 = @norm1.backward(d_ff).as(CudaMatrix)
-      d_attn = @mha.backward(d_norm1).as(CudaMatrix)
-      d_attn.add!(d_norm1.as(CudaMatrix))
-      d_attn
+      if @pre_norm
+        d_ff_input = @ffn.backward(d_out).as(CudaMatrix)
+        d_ff_input.add!(d_out.as(CudaMatrix))
+        d_residual1 = @norm2.backward(d_ff_input).as(CudaMatrix)
+        d_attn_input = @mha.backward(d_residual1).as(CudaMatrix)
+        d_x = @norm1.backward(d_attn_input).as(CudaMatrix)
+        d_x.add!(d_residual1.as(CudaMatrix))
+        d_x
+      else
+        d_norm2 = @norm2.backward(d_out)
+        d_ff = @ffn.backward(d_norm2).as(CudaMatrix)
+        d_ff.add!(d_norm2.as(CudaMatrix))
+        d_norm1 = @norm1.backward(d_ff).as(CudaMatrix)
+        d_attn = @mha.backward(d_norm1).as(CudaMatrix)
+        d_attn.add!(d_norm1.as(CudaMatrix))
+        d_attn
+      end
     end
 
     # CPU path backward - all SimpleMatrix operations
     def backward(d_out : SimpleMatrix) : SimpleMatrix
-      d_norm2 = @norm2.backward(d_out)
-      d_ff = @ffn.backward(d_norm2).as(SimpleMatrix)
-      d_ff.add!(d_norm2.as(SimpleMatrix))
-      d_norm1 = @norm1.backward(d_ff)
-      d_attn = @mha.backward(d_norm1).as(SimpleMatrix)
-      d_attn.add!(d_norm1.as(SimpleMatrix))
-      d_attn
+      if @pre_norm
+        d_ff_input = @ffn.backward(d_out).as(SimpleMatrix)
+        d_ff_input.add!(d_out.as(SimpleMatrix))
+        d_residual1 = @norm2.backward(d_ff_input).as(SimpleMatrix)
+        d_attn_input = @mha.backward(d_residual1).as(SimpleMatrix)
+        d_x = @norm1.backward(d_attn_input)
+        d_x.add!(d_residual1.as(SimpleMatrix))
+        d_x
+      else
+        d_norm2 = @norm2.backward(d_out)
+        d_ff = @ffn.backward(d_norm2).as(SimpleMatrix)
+        d_ff.add!(d_norm2.as(SimpleMatrix))
+        d_norm1 = @norm1.backward(d_ff)
+        d_attn = @mha.backward(d_norm1).as(SimpleMatrix)
+        d_attn.add!(d_norm1.as(SimpleMatrix))
+        d_attn
+      end
     end
 
     def apply_gradients(lr : Float64)


### PR DESCRIPTION
## Summary
- add `pre_norm` option to `TransformerBlock`
- support pre-norm in network helper
- document the option in README
- test pre-norm and post-norm behaviours

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686d6501c4f883318f3cee2f6b578039