### PR TITLE
Use GELU and attention masks in BabyLM example

### DIFF
--- a/examples/transformer_pe.cr
+++ b/examples/transformer_pe.cr
@@ -3,7 +3,7 @@ require "../src/shainet"
 # Simple demonstration of using a Transformer layer with sinusoidal positional encoding.
 
 # Create a tiny Transformer layer
-layer = SHAInet::TransformerLayer.new(2, 1, 4)
+layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
 
 # Two-step input sequence (2 x 2 matrix)
 input = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -114,7 +114,7 @@ end
 describe SHAInet::TransformerLayer do
   it "overfits a tiny sequence" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
-    layer = SHAInet::TransformerLayer.new(2, 1, 4)
+    layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
     input = if SHAInet::CUDA.fully_available?
               SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
             else
@@ -144,7 +144,7 @@ describe SHAInet::TransformerLayer do
 
   it "overfits with positional encoding" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
-    layer = SHAInet::TransformerLayer.new(2, 1, 4)
+    layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
     input = if SHAInet::CUDA.fully_available?
               SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
             else

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -106,7 +106,7 @@ module SHAInet
                 raise NeuralNetRunError.new("vocab_size required for embedding layer") if vocab_size <= 0
                 EmbeddingLayer.new(vocab_size, l_size, activation_function)
               when "transformer"
-                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent, pre_norm)
+                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent, pre_norm, activation_function)
               else
                 # Use MatrixLayer for regular feedforward layers - it has proper GPU support and gradient computation
                 # Note: MatrixLayer will be properly connected with correct input size in connect_ltl


### PR DESCRIPTION
## Summary
- add optional mask to TransformerBlock and allow specifying feedforward activation
- wire activation through network setup
- default BabyLM transformer layers to GELU
- apply causal mask for language modeling
- update specs for new TransformerLayer API

## Testing
- `crystal spec --error-on-warnings`
- `bin/ameba` *(fails: 380 failures)*

------
https://chatgpt.com/codex/tasks/task_e_686e2de55ee083319dbbb45967e24a5c