### PR TITLE
Enable weight decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Set `accumulation_steps` to accumulate gradients across several mini-batches whe
 ```crystal
 net.accumulation_steps = 2 # updates weights every 2 mini-batches
 ```
+
+Enable weight decay to shrink parameters on each update:
+
+```crystal
+net.weight_decay = 0.01
+```
 ---
 
 ## Advanced

--- a/examples/transformer_pe.cr
+++ b/examples/transformer_pe.cr
@@ -29,7 +29,7 @@ target = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(2, 2))
            out.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
          end
   layer.backward(diff)
-  layer.apply_gradients(0.05)
+  layer.apply_gradients(0.05, 0.0)
 end
 
 puts "Output after training:"

--- a/spec/embedding_cuda_parity_spec.cr
+++ b/spec/embedding_cuda_parity_spec.cr
@@ -24,7 +24,7 @@ describe "Embedding GPU parity" do
     cpu_layer.embed(1)
     cpu_layer.gradients[1, 0] = 0.2
     cpu_layer.gradients[1, 1] = 0.2
-    cpu_layer.apply_gradients(lr)
+    cpu_layer.apply_gradients(lr, 0.0)
 
     # Now with GPU
     ENV.delete("SHAINET_DISABLE_CUDA")
@@ -50,7 +50,7 @@ describe "Embedding GPU parity" do
     if gpu_layer.gradients.is_a?(SHAInet::CudaMatrix)
       gpu_layer.gradients.as(SHAInet::CudaMatrix).sync_to_device!
     end
-    gpu_layer.apply_gradients(lr)
+    gpu_layer.apply_gradients(lr, 0.0)
 
     # Check results for updated values
     vocab_size.times do |r|

--- a/spec/embedding_layer_spec.cr
+++ b/spec/embedding_layer_spec.cr
@@ -29,7 +29,7 @@ describe SHAInet::EmbeddingLayer do
     layer.gradients[1, 1] = 0.1
 
     # Apply gradients with a learning rate
-    layer.apply_gradients(0.1)
+    layer.apply_gradients(0.1, 0.0)
 
     after = layer.lookup(1)
     puts "After: #{after.inspect}, embeddings at 1: #{layer.embeddings[1, 0]}, #{layer.embeddings[1, 1]}"

--- a/spec/matrix_layer_spec.cr
+++ b/spec/matrix_layer_spec.cr
@@ -80,4 +80,19 @@ describe SHAInet::MatrixLayer do
       layer.biases[0, j].should be_close(expected_b[0, j], 1e-6)
     end
   end
+
+  it "shrinks weights with weight decay" do
+    mat_klass = SHAInet::CUDA.fully_available? ? SHAInet::CudaMatrix : SHAInet::SimpleMatrix
+    layer = SHAInet::MatrixLayer.new(1, 2, SHAInet.none)
+    layer.weights = mat_klass.from_a([[0.5, -0.5]])
+    layer.g_w = mat_klass.zeros(1, 2)
+    old_w = layer.weights.clone
+
+    layer.update_weights(0.0, 0.1)
+
+    2.times do |j|
+      expected = (old_w[0, j] * (1.0 - 0.1))
+      layer.weights[0, j].should be_close(expected, 1e-6)
+    end
+  end
 end

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -47,9 +47,9 @@ describe SHAInet::MultiHeadAttention do
              end
       attn.backward(diff)
       if SHAInet::CUDA.fully_available?
-        attn.apply_gradients(0.2, SHAInet::CudaMatrix)
+        attn.apply_gradients(0.2, SHAInet::CudaMatrix, 0.0)
       else
-        attn.apply_gradients(0.2, SHAInet::SimpleMatrix)
+        attn.apply_gradients(0.2, SHAInet::SimpleMatrix, 0.0)
       end
     end
     out = attn.forward(input)
@@ -134,7 +134,7 @@ describe SHAInet::TransformerLayer do
         diff = output.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
       end
       layer.backward(diff)
-      layer.apply_gradients(0.05)
+      layer.apply_gradients(0.05, 0.0)
     end
 
     output = layer.forward(input)
@@ -168,7 +168,7 @@ describe SHAInet::TransformerLayer do
                out.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
              end
       layer.backward(diff)
-      layer.apply_gradients(0.05)
+      layer.apply_gradients(0.05, 0.0)
     end
     out = layer.forward(input)
     out = if SHAInet::CUDA.fully_available?

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -832,7 +832,6 @@ module SHAInet
           Log.info { "Training stopped early. Error threshold reached: #{avg_error} < #{error_threshold}" }
           break
         end
-
       end
 
       elapsed = Time.monotonic - start_time
@@ -1195,14 +1194,14 @@ module SHAInet
 
         @hidden_layers.each do |layer|
           if layer.is_a?(MatrixLayer)
-            layer.update_weights(learning_rate)
+            layer.update_weights(learning_rate, @weight_decay)
           elsif layer.is_a?(EmbeddingLayer)
-            layer.apply_gradients(learning_rate)
+            layer.apply_gradients(learning_rate, @weight_decay)
           end
         end
 
         @output_layers.each do |layer|
-          layer.update_weights(learning_rate) if layer.is_a?(MatrixLayer)
+          layer.update_weights(learning_rate, @weight_decay) if layer.is_a?(MatrixLayer)
         end
 
         update_transformer_layers if @transformer_layers.any?
@@ -1318,7 +1317,7 @@ module SHAInet
     def update_transformer_layers
       lr = current_learning_rate
       @transformer_layers.each do |layer|
-        layer.apply_gradients(lr)
+        layer.apply_gradients(lr, @weight_decay)
       end
     end
 

--- a/src/shainet/transformer/transformer_block.cr
+++ b/src/shainet/transformer/transformer_block.cr
@@ -176,24 +176,24 @@ module SHAInet
       end
     end
 
-    def apply_gradients(lr : Float64)
+    def apply_gradients(lr : Float64, weight_decay : Float64 = 0.0)
       # Determine device type from weights
       if @weights.is_a?(CudaMatrix)
         # GPU path
-        @ffn.apply_gradients(lr) # PositionWiseFF uses standard apply_gradients method
-        @mha.apply_gradients(lr, CudaMatrix)
+        @ffn.apply_gradients(lr, weight_decay) # PositionWiseFF uses standard apply_gradients method
+        @mha.apply_gradients(lr, CudaMatrix, weight_decay)
       else
         # CPU path
-        @ffn.apply_gradients(lr) # PositionWiseFF uses standard apply_gradients method
-        @mha.apply_gradients(lr, SimpleMatrix)
+        @ffn.apply_gradients(lr, weight_decay) # PositionWiseFF uses standard apply_gradients method
+        @mha.apply_gradients(lr, SimpleMatrix, weight_decay)
       end
-      @norm1.apply_gradients(lr)
-      @norm2.apply_gradients(lr)
+      @norm1.apply_gradients(lr, weight_decay)
+      @norm2.apply_gradients(lr, weight_decay)
     end
 
     # Override MatrixLayer's update_weights to prevent conflicts
     # TransformerBlock manages its own weight updates through apply_gradients
-    def update_weights(learning_rate : Float64)
+    def update_weights(learning_rate : Float64, weight_decay : Float64 = 0.0)
       # No-op: weights are updated via apply_gradients in update_transformer_layers
     end
 


### PR DESCRIPTION
## Summary
- implement weight decay in `MatrixLayer` update routines
- pass `weight_decay` from `Network` when updating layers
- extend embedding and transformer gradient updates to accept weight decay
- add unit test for weight decay behaviour
- document weight decay usage

## Testing
- `crystal spec spec/matrix_layer_spec.cr spec/embedding_layer_spec.cr spec/embedding_cuda_parity_spec.cr spec/transformer_spec.cr spec/lr_scheduler_spec.cr -v`

------
https://chatgpt.com/codex/tasks/task_e_686e3691198083319cc60074d575202b