### PR TITLE
Add KVCache struct for transformer caching

### DIFF
--- a/spec/kv_cache_spec.cr
+++ b/spec/kv_cache_spec.cr
@@ -1,0 +1,22 @@
+require "./spec_helper"
+
+describe SHAInet::KVCache do
+  it "stores and clears values" do
+    cache = SHAInet::KVCache.new(2, 2)
+    k = SHAInet::SimpleMatrix.zeros(1, 1)
+    v = SHAInet::SimpleMatrix.ones(1, 1)
+
+    cache.append!(0, 0, k, v)
+    cache.keys[0][0].size.should eq(1)
+    cache.values[0][0].size.should eq(1)
+
+    cache.clear_layer!(0)
+    cache.keys[0][0].size.should eq(0)
+    cache.values[0][0].size.should eq(0)
+
+    cache.append!(1, 1, k, v)
+    cache.clear!
+    cache.keys.each { |layer| layer.each { |head| head.size.should eq(0) } }
+    cache.values.each { |layer| layer.each { |head| head.size.should eq(0) } }
+  end
+end

--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -40,6 +40,7 @@ require "./shainet/transformer/multi_head_attention"
 require "./shainet/transformer/positional_encoding"
 require "./shainet/transformer/positionwise_ff"
 require "./shainet/transformer/mask_utils"
+require "./shainet/transformer/kv_cache"
 require "./shainet/transformer/transformer_block"
 require "./shainet/version"
 

--- a/src/shainet/transformer/kv_cache.cr
+++ b/src/shainet/transformer/kv_cache.cr
@@ -1,0 +1,48 @@
+module SHAInet
+  # KVCache stores cached key and value tensors per transformer layer and head.
+  # Each layer contains an array of heads, each head stores an array of matrices
+  # appended sequentially during autoregressive decoding.
+  struct KVCache
+    getter keys : Array(Array(Array(SimpleMatrix | CudaMatrix)))
+    getter values : Array(Array(Array(SimpleMatrix | CudaMatrix)))
+
+    # Allocate empty caches for `num_layers` layers, each with `num_heads` heads.
+    def initialize(num_layers : Int32, num_heads : Int32)
+      @keys = Array(Array(Array(SimpleMatrix | CudaMatrix))).new(num_layers) do
+        Array(Array(SimpleMatrix | CudaMatrix)).new(num_heads) { [] of (SimpleMatrix | CudaMatrix) }
+      end
+      @values = Array(Array(Array(SimpleMatrix | CudaMatrix))).new(num_layers) do
+        Array(Array(SimpleMatrix | CudaMatrix)).new(num_heads) { [] of (SimpleMatrix | CudaMatrix) }
+      end
+    end
+
+    # Append a new key/value pair to the cache for the given layer and head.
+    def append!(layer : Int32, head : Int32, key : SimpleMatrix | CudaMatrix, value : SimpleMatrix | CudaMatrix)
+      validate_indices(layer, head)
+      @keys[layer][head] << key
+      @values[layer][head] << value
+    end
+
+    # Clear all cached keys and values.
+    def clear!
+      @keys.each { |layer| layer.each(&.clear) }
+      @values.each { |layer| layer.each(&.clear) }
+    end
+
+    # Clear cached entries for a specific layer.
+    def clear_layer!(layer : Int32)
+      validate_layer(layer)
+      @keys[layer].each(&.clear)
+      @values[layer].each(&.clear)
+    end
+
+    private def validate_layer(layer : Int32)
+      raise ArgumentError.new("layer index out of range") unless layer < @keys.size
+    end
+
+    private def validate_indices(layer : Int32, head : Int32)
+      validate_layer(layer)
+      raise ArgumentError.new("head index out of range") unless head < @keys[layer].size
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- introduce `SHAInet::KVCache` to store cached key/value tensors by layer and head
- include helper methods for appending and clearing cache entries
- add unit test for KVCache
- require the new module in `shainet.cr`

## Testing
- `crystal spec spec/kv_cache_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_686e4892bb7c8331ba82cbf07a472b26