### PR TITLE
Refactor Float16 using LLVM intrinsics

### DIFF
--- a/spec/precision_spec.cr
+++ b/spec/precision_spec.cr
@@ -25,4 +25,24 @@ describe "Precision enum" do
     h = SHAInet::Float16.new(1.5_f32)
     (h.to_f32 - 1.5_f32).abs.should be < 0.01
   end
+
+  it "roundtrips Float32 values" do
+    v = 3.1415_f32
+    h = SHAInet::Float16.new(v)
+    (h.to_f32 - v).abs.should be < 0.01
+  end
+
+  it "roundtrips Float64 values" do
+    v = 3.1415926535_f64
+    h = SHAInet::Float16.new(v)
+    (h.to_f64 - v).abs.should be < 0.01
+  end
+
+  it "uses Float32/64 to_f16 helpers" do
+    h1 = 1.25_f32.to_f16
+    (h1.to_f32 - 1.25_f32).abs.should be < 0.01
+
+    h2 = 1.25_f64.to_f16
+    (h2.to_f64 - 1.25_f64).abs.should be < 0.01
+  end
 end

--- a/src/shainet/float16.cr
+++ b/src/shainet/float16.cr
@@ -1,71 +1,37 @@
 module SHAInet
-  # Simple half precision float wrapper using 16-bit storage.
-  # Provides conversion from/to Float32.
-  struct Float16
-    @bits : UInt16
+  # LLVM intrinsic helpers for half precision conversions
+  lib LibIntrinsics
+    fun f16tof32 = "llvm.convert.from.fp16.f32"(Int16) : Float32
+    fun f16tof64 = "llvm.convert.from.fp16.f64"(Int16) : Float64
+    fun f32tof16 = "llvm.convert.to.fp16.f32"(Float32) : Int16
+    fun f64tof16 = "llvm.convert.to.fp16.f64"(Float64) : Int16
+  end
 
-    def initialize(value : Float32)
-      @bits = Float16.to_bits(value)
+  @[Extern]
+  struct Float16
+    @value : Int16
+
+    def self.new(value : Float32)
+      new LibIntrinsics.f32tof16(value)
     end
 
-    # Return the Float32 representation
+    def self.new(value : Float64)
+      new LibIntrinsics.f64tof16(value)
+    end
+
+    private def initialize(@value : Int16)
+    end
+
     def to_f32 : Float32
-      Float16.from_bits(@bits)
+      LibIntrinsics.f16tof32(@value)
     end
 
     def to_f64 : Float64
-      to_f32.to_f64
+      LibIntrinsics.f16tof64(@value)
     end
 
-    def self.to_bits(v : Float32) : UInt16
-      ui = v.unsafe_as(UInt32)
-      sign = (ui >> 31) & 0x1
-      exp = (ui >> 23) & 0xff
-      mant = ui & 0x7fffff
-
-      half_exp = 0
-      half_mant = 0
-
-      if exp == 255
-        half_exp = 31
-        half_mant = mant >> 13
-      elsif exp > 142
-        half_exp = 31
-        half_mant = 0
-      elsif exp >= 113
-        half_exp = exp - 112
-        half_mant = mant >> 13
-      elsif exp >= 111
-        half_exp = 0
-        half_mant = (mant | 0x800000) >> (126 - exp)
-      else
-        return ((sign << 15)).to_u16
-      end
-      ((sign << 15) | (half_exp << 10) | half_mant).to_u16
-    end
-
-    def self.from_bits(bits : UInt16) : Float32
-      sign = ((bits & 0x8000).to_u32) << 16
-      exp = ((bits >> 10) & 0x1f).to_u32
-      mant = (bits & 0x3ff).to_u32
-
-      if exp == 0
-        if mant == 0
-          return sign.unsafe_as(Float32)
-        else
-          while (mant & 0x400) == 0
-            mant <<= 1
-            exp -= 1
-          end
-          exp += 1
-          mant &= 0x3ff
-        end
-      elsif exp == 31
-        return (sign | 0x7f800000 | (mant << 13)).unsafe_as(Float32)
-      end
-
-      exp = exp + (127 - 15)
-      (sign | (exp << 23) | (mant << 13)).unsafe_as(Float32)
+    def to_f : Float64
+      to_f64
     end
   end
 
@@ -84,5 +50,18 @@ module SHAInet
     def to_f64 : Float64
       to_f32.to_f64
     end
+  end
+end
+
+# Convenience conversion helpers
+struct Float32
+  def to_f16 : SHAInet::Float16
+    SHAInet::Float16.new(self)
+  end
+end
+
+struct Float64
+  def to_f16 : SHAInet::Float16
+    SHAInet::Float16.new(self)
   end
 end


### PR DESCRIPTION
## Summary
- reimplement `Float16` using LLVM intrinsics
- add `to_f16` helpers on `Float32` and `Float64`
- add conversion specs covering Float32/64 roundtrips

## Testing
- `crystal spec -v`


------
https://chatgpt.com/codex/tasks/task_e_686e5a282b8083319495249b1c8500fe