### PR TITLE
Add Int8 precision and quantization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ SHAInet (Super Human Artificial Intelligence Network) is a neural network librar
 - Residual skip connections between layers
 - PyTorch and HuggingFace model import
 - Transformer and modern NLP support
-- Configurable precision (fp64/fp32/fp16/bf16)
+- Configurable precision (fp64/fp32/fp16/bf16/int8)
 - Includes lightweight Float16/BFloat16 wrappers for half precision
+- Supports INT8 quantization for efficient inference
 - Enable half precision by setting `net.precision = SHAInet::Precision::Fp16`
   or `SHAInet::Precision::Bf16`.
 

--- a/spec/precision_spec.cr
+++ b/spec/precision_spec.cr
@@ -25,4 +25,10 @@ describe "Precision enum" do
     h = SHAInet::Float16.new(1.5_f32)
     (h.to_f32 - 1.5_f32).abs.should be < 0.01
   end
+
+  it "quantizes and dequantizes int8 values" do
+    scale, zp = SHAInet.compute_int8_scale_zero_point(-1.0_f32, 1.0_f32)
+    q = SHAInet::Int8Value.from_f32(0.5_f32, scale, zp)
+    (q.to_f32(scale, zp) - 0.5_f32).abs.should be < scale
+  end
 end

--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -7,6 +7,7 @@ require "log"
   require "./shainet/cuda_stub"
 {% end %}
 require "./shainet/precision"
+require "./shainet/int8"
 
 require "./shainet/autograd/tensor"
 require "./shainet/basic/exceptions"

--- a/src/shainet/int8.cr
+++ b/src/shainet/int8.cr
@@ -1,0 +1,29 @@
+module SHAInet
+  # Wrapper for an INT8 value with helper conversion methods.
+  struct Int8Value
+    getter value : Int8
+
+    def initialize(@value : Int8)
+    end
+
+    # Create an Int8Value from a Float32 using scale and zero_point
+    def self.from_f32(v : Float32, scale : Float32, zero_point : Int8)
+      q = ((v / scale).round.to_i + zero_point).clamp(-128, 127)
+      new(q.to_i8)
+    end
+
+    # Convert back to Float32 given scale and zero_point
+    def to_f32(scale : Float32, zero_point : Int8) : Float32
+      (@value - zero_point).to_f32 * scale
+    end
+  end
+
+  # Compute scale and zero-point for mapping the range [min,max] to INT8
+  def self.compute_int8_scale_zero_point(min : Float32, max : Float32) : {Float32, Int8}
+    qmin = -128.0_f32
+    qmax = 127.0_f32
+    scale = (max - min) / (qmax - qmin)
+    zero_point = (qmin - min / scale).round.clamp(qmin, qmax).to_i8
+    {scale, zero_point}
+  end
+end

--- a/src/shainet/precision.cr
+++ b/src/shainet/precision.cr
@@ -7,5 +7,6 @@ module SHAInet
     Fp32
     Fp16
     Bf16
+    Int8
   end
 end


### PR DESCRIPTION
## Summary
- support `Int8` in `SHAInet::Precision`
- add `Int8Value` wrapper and helpers for int8 quantization
- expose int8 helper in `shainet.cr`
- document int8 quantization in README
- test int8 conversions

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686e617fc6bc83319778c1875b432927