### PR TITLE
Fix workspace leak in PositionWiseFF

### DIFF
--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -222,8 +222,6 @@ module SHAInet
 
       d_input = CudaMatrix.get_workspace(drelu.rows, w1_gpu.rows, "pw_d_input")
       d_input.gemm!(drelu, @w1_t.as(CudaMatrix))
-      CudaMatrix.return_workspace(drelu)
-
       d_input
     end
 


### PR DESCRIPTION
## Summary
- avoid returning persistent workspace matrix during backprop

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686e63e9d6e88331bbb4f38498fbf235