### PR TITLE
Add INT8 matrix support and gemm_int8

### DIFF
--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -1,19 +1,43 @@
 module SHAInet
+  # Minimal matrix implementation used as the CPU fallback for
+  # CudaMatrix.  Originally this class only supported `Float64`
+  # storage.  To support INT8 quantised models we extend it with a
+  # `precision` flag and optionally store values as `Int8`.
   class SimpleMatrix
     property rows : Int32
     property cols : Int32
-    getter data : Array(Float64)
+    property precision : Precision
 
-    def initialize(@rows : Int32, @cols : Int32, init : Float64 = 0.0)
-      @data = Array(Float64).new(@rows * @cols, init)
+    # Backing storage for the matrix.  Depending on the precision we
+    # either allocate a `Float64` array or an `Int8` array.
+    @data_f64 : Array(Float64)?
+    @data_i8 : Array(Int8)?
+
+    # Provide access to the underlying Float64 array when in floating
+    # point mode. This keeps compatibility with older code which
+    # accessed `matrix.data` directly.
+    def data
+      @data_f64.not_nil!
     end
 
-    def self.zeros(rows : Int32, cols : Int32)
-      new(rows, cols, 0.0)
+    def initialize(@rows : Int32, @cols : Int32,
+                   init : Float64 = 0.0,
+                   @precision : Precision = Precision::Fp64)
+      if @precision == Precision::Int8
+        @data_i8 = Array(Int8).new(@rows * @cols, init.round.to_i8)
+        @data_f64 = nil
+      else
+        @data_f64 = Array(Float64).new(@rows * @cols, init)
+        @data_i8 = nil
+      end
     end
 
-    def self.ones(rows : Int32, cols : Int32)
-      new(rows, cols, 1.0)
+    def self.zeros(rows : Int32, cols : Int32, precision : Precision = Precision::Fp64)
+      new(rows, cols, 0.0, precision)
+    end
+
+    def self.ones(rows : Int32, cols : Int32, precision : Precision = Precision::Fp64)
+      new(rows, cols, 1.0, precision)
     end
 
     def self.tensor(rows : Int32, cols : Int32)
@@ -21,11 +45,21 @@ module SHAInet
     end
 
     def [](r : Int32, c : Int32)
-      @data[r * @cols + c]
+      idx = r * @cols + c
+      if @precision == Precision::Int8
+        @data_i8.not_nil![idx].to_f64
+      else
+        @data_f64.not_nil![idx]
+      end
     end
 
     def []=(r : Int32, c : Int32, v : Float64)
-      @data[r * @cols + c] = v
+      idx = r * @cols + c
+      if @precision == Precision::Int8
+        @data_i8.not_nil![idx] = v.round.clamp(-128, 127).to_i8
+      else
+        @data_f64.not_nil![idx] = v
+      end
     end
 
     def +(other : SimpleMatrix)
@@ -108,10 +142,10 @@ module SHAInet
     end
 
     # Construct a matrix from a nested Array
-    def self.from_a(array : Array(Array(GenNum)))
+    def self.from_a(array : Array(Array(GenNum)), precision : Precision = Precision::Fp64)
       rows = array.size
       cols = array.first.size
-      m = SimpleMatrix.new(rows, cols)
+      m = SimpleMatrix.new(rows, cols, 0.0, precision)
       rows.times do |i|
         cols.times do |j|
           m[i, j] = array[i][j].to_f64
@@ -237,7 +271,7 @@ module SHAInet
 
     # Convert SimpleMatrix to CudaMatrix for GPU operations
     def to_cuda : CudaMatrix
-      result = CudaMatrix.new(@rows, @cols)
+      result = CudaMatrix.new(@rows, @cols, precision: @precision)
       # Use batch copy through raw data for better performance
       @rows.times do |i|
         @cols.times do |j|
@@ -245,6 +279,27 @@ module SHAInet
         end
       end
       result.sync_to_device!("simple_to_cuda_conversion")
+      result
+    end
+
+    # Matrix multiplication for INT8 matrices. The result is returned as a
+    # regular floating point SimpleMatrix. This is a simple CPU
+    # implementation used when CUDA is not available.
+    def self.gemm_int8(a : SimpleMatrix, b : SimpleMatrix) : SimpleMatrix
+      raise ArgumentError.new("precision mismatch") unless a.precision == Precision::Int8 && b.precision == Precision::Int8
+      raise ArgumentError.new("size mismatch") unless a.cols == b.rows
+
+      result = SimpleMatrix.new(a.rows, b.cols)
+      a.rows.times do |i|
+        b.cols.times do |j|
+          sum = 0_i32
+          a.cols.times do |k|
+            sum += a.instance_variable_get("@data_i8").as(Array(Int8))[i * a.cols + k].to_i32 *
+                   b.instance_variable_get("@data_i8").as(Array(Int8))[k * b.cols + j].to_i32
+          end
+          result[i, j] = sum.to_f64
+        end
+      end
       result
     end
 


### PR DESCRIPTION
## Summary
- extend `SimpleMatrix` and `CudaMatrix` with `precision` and optional INT8 storage
- add CPU `gemm_int8` implementation
- add GPU `gemm_int8` using `cublasGemmEx`
- expose INT8 datatypes in CUDA wrapper

## Testing
- `crystal spec --fail-fast` *(fails: Transformer cached inference produces same output as full run and stores keys)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d1c8ca88331b5d733c61c6158f3