### PR TITLE
Add precision flag to SimpleMatrix

### DIFF
--- a/spec/simple_matrix_precision_spec.cr
+++ b/spec/simple_matrix_precision_spec.cr
@@ -1,0 +1,15 @@
+require "./spec_helper"
+
+describe SHAInet::SimpleMatrix do
+  it "allocates based on precision" do
+    m = SHAInet::SimpleMatrix.zeros(2, 2, SHAInet::Precision::Fp32)
+    m.precision.should eq(SHAInet::Precision::Fp32)
+    m.data.should be_a(Array(Float32))
+  end
+
+  it "converts to_f32 and to_f64" do
+    m = SHAInet::SimpleMatrix.ones(1, 2, SHAInet::Precision::Fp16)
+    m.to_f32.size.should eq(2)
+    m.to_f64[0].should be_close(1.0, 1e-6)
+  end
+end

--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -71,7 +71,8 @@ module SHAInet
 
       # Keep CPU copy in sync
       dest_slice = Slice(Float64).new(dest.raw_data.to_unsafe, size)
-      src_slice = Slice(Float64).new(src.data.to_unsafe, size)
+      src_data = src.to_f64
+      src_slice = Slice(Float64).new(src_data.to_unsafe, size)
       dest_slice.copy_from(src_slice)
 
       if (dptr = dest.device_ptr) && !dptr.null?
@@ -94,7 +95,8 @@ module SHAInet
       bytes = (size * 8).to_u64
 
       dest_slice = Slice(Float64).new(dest.raw_data.to_unsafe, size)
-      src_slice = Slice(Float64).new(matrix.data.to_unsafe, size)
+      src_data = matrix.to_f64
+      src_slice = Slice(Float64).new(src_data.to_unsafe, size)
       dest_slice.copy_from(src_slice)
 
       if (dptr = dest.device_ptr) && !dptr.null?


### PR DESCRIPTION
## Summary
- add precision-aware storage for `SimpleMatrix`
- handle precision when copying matrices to GPU
- expose `to_f32`/`to_f64` helpers
- test new helpers and precision handling

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_686e6d49acb083318c74a7205db7782e