### PR TITLE
Fix CUDA finalizer crash

### DIFF
--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -281,10 +281,9 @@ module SHAInet
     end
 
     def finalize
-      if ws = @workspace_result
-        CudaMatrix.return_workspace(ws)
-        @workspace_result = nil
-      end
+      # Only release reference to allow CudaMatrix's own finalizer
+      # to free GPU memory without performing allocations here.
+      @workspace_result = nil
     end
   end
 end

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -524,27 +524,9 @@ module SHAInet
 
     def finalize
       if CUDA.fully_available?
-        if ws = @workspace_mean
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_var
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_norm
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_result
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_d_x
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_d_gamma
-          CudaMatrix.return_workspace(ws)
-        end
-        if ws = @workspace_d_beta
-          CudaMatrix.return_workspace(ws)
-        end
+        # Avoid returning workspace matrices to the pool from a finalizer to
+        # prevent allocations during GC. Dropping the references is enough for
+        # their own finalizers to free GPU memory.
       end
 
       @workspace_mean = nil

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -917,53 +917,27 @@ module SHAInet
           @v_t_ws,
           @scores_t_ws,
           @d_concat_slices_ws,
-        ].each do |arr|
-          arr.each { |ws| CudaMatrix.return_workspace(ws) if ws }
-          arr.clear
-        end
-
-        [
-          @workspace_concat,
-          @workspace_d_q_concat,
-          @workspace_d_k_concat,
-          @workspace_d_v_concat,
-          @workspace_q,
-          @workspace_k,
-          @workspace_v,
-          @workspace_d_x_q,
-          @workspace_d_x_k,
-          @workspace_d_x_v,
-          @workspace_x_t,
-          @workspace_concat_t,
-          @workspace_w_o_t,
-          @workspace_temp_grad_o,
-          @workspace_temp_grad_q,
-          @workspace_temp_grad_k,
-          @workspace_temp_grad_v,
-          @workspace_d_x,
-        ].each do |ws|
-          CudaMatrix.return_workspace(ws) if ws
-        end
-
-        @workspace_concat = nil
-        @workspace_d_q_concat = nil
-        @workspace_d_k_concat = nil
-        @workspace_d_v_concat = nil
-        @workspace_q = nil
-        @workspace_k = nil
-        @workspace_v = nil
-        @workspace_d_x_q = nil
-        @workspace_d_x_k = nil
-        @workspace_d_x_v = nil
-        @workspace_x_t = nil
-        @workspace_concat_t = nil
-        @workspace_w_o_t = nil
-        @workspace_temp_grad_o = nil
-        @workspace_temp_grad_q = nil
-        @workspace_temp_grad_k = nil
-        @workspace_temp_grad_v = nil
-        @workspace_d_x = nil
+        ].each(&.clear)
       end
+
+      @workspace_concat = nil
+      @workspace_d_q_concat = nil
+      @workspace_d_k_concat = nil
+      @workspace_d_v_concat = nil
+      @workspace_q = nil
+      @workspace_k = nil
+      @workspace_v = nil
+      @workspace_d_x_q = nil
+      @workspace_d_x_k = nil
+      @workspace_d_x_v = nil
+      @workspace_x_t = nil
+      @workspace_concat_t = nil
+      @workspace_w_o_t = nil
+      @workspace_temp_grad_o = nil
+      @workspace_temp_grad_q = nil
+      @workspace_temp_grad_k = nil
+      @workspace_temp_grad_v = nil
+      @workspace_d_x = nil
     end
   end
 end

--- a/src/shainet/transformer/positionwise_ff.cr
+++ b/src/shainet/transformer/positionwise_ff.cr
@@ -493,12 +493,21 @@ module SHAInet
 
     def finalize
       if CUDA.fully_available?
-        [@workspace_w2_t, @workspace_w1_t, @workspace_temp_grad_w2,
-         @workspace_temp_grad_w1, @workspace_x_t, @workspace_h_t, @workspace_h,
-         @workspace_out, @workspace_d_input, @workspace_dh].each do |ws|
-          CudaMatrix.return_workspace(ws.not_nil!) if ws
-        end
+        # Avoid returning matrices to the workspace pool from a finalizer to
+        # prevent allocations while the GC is running. Simply drop references so
+        # each CudaMatrix can clean itself up.
       end
+
+      @workspace_w2_t = nil
+      @workspace_w1_t = nil
+      @workspace_temp_grad_w2 = nil
+      @workspace_temp_grad_w1 = nil
+      @workspace_x_t = nil
+      @workspace_h_t = nil
+      @workspace_h = nil
+      @workspace_out = nil
+      @workspace_d_input = nil
+      @workspace_dh = nil
     end
   end
 end


### PR DESCRIPTION
## Summary
- avoid GPU workspace pool operations in layer finalizers

## Testing
- `make test` *(fails: GPU acceleration not available)*

------
https://chatgpt.com/codex/tasks/task_e_686e7661947c8331ab92811094ebe22a