### PR TITLE
Add dimension checks in LayerNorm backward

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1152,7 +1152,7 @@ module SHAInet
 
             # Get the transformer's d_model dimension from layer size
             d_model = @transformer_layers.first.size
-            seq_len = 16 # hardcoded for now, should be dynamic
+            seq_len = input_matrix.rows
 
             if grad.rows == 1 && grad.cols != d_model
               # We have output gradients (1 x vocab_size), need to transform to (seq_len x d_model)

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -334,6 +334,9 @@ module SHAInet
     # GPU path backward - all CudaMatrix operations
     def backward(d_out : CudaMatrix) : CudaMatrix
       x = @x.as(CudaMatrix)
+      if d_out.rows != x.rows || d_out.cols != x.cols
+        raise ArgumentError.new("dimension mismatch")
+      end
       rows = x.rows
       cols = x.cols
 
@@ -423,6 +426,9 @@ module SHAInet
     # CPU path backward - all SimpleMatrix operations
     def backward(d_out : SimpleMatrix) : SimpleMatrix
       x = @x.as(SimpleMatrix)
+      if d_out.rows != x.rows || d_out.cols != x.cols
+        raise ArgumentError.new("dimension mismatch")
+      end
       rows = x.rows
       cols = x.cols
 


### PR DESCRIPTION
## Summary
- validate dimensions in `LayerNorm#backward` for both GPU and CPU paths
- compute transformer gradient expansion using current sequence length

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686e76bcd37083319737a1b8744fc760