### PR TITLE
Add LayerNorm gradient shape checks and tests

### DIFF
--- a/spec/layer_norm_shape_spec.cr
+++ b/spec/layer_norm_shape_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+describe SHAInet::LayerNorm do
+  it "raises on gradient shape mismatch on GPU" do
+    pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
+
+    d_model = 4
+    batch = 2
+    ln = SHAInet::LayerNorm.new(d_model)
+    x = SHAInet::CudaMatrix.zeros(batch, d_model)
+    ln.forward(x)
+    wrong = SHAInet::CudaMatrix.zeros(batch, d_model + 1)
+
+    expect_raises(ArgumentError) do
+      ln.backward(wrong)
+    end
+  end
+
+  it "raises on gradient shape mismatch on CPU" do
+    ENV["SHAINET_DISABLE_CUDA"] = "1"
+    d_model = 4
+    batch = 2
+    ln = SHAInet::LayerNorm.new(d_model)
+    x = SHAInet::SimpleMatrix.zeros(batch, d_model)
+    ln.forward(x)
+    wrong = SHAInet::SimpleMatrix.zeros(batch + 1, d_model)
+
+    expect_raises(ArgumentError) do
+      ln.backward(wrong)
+    end
+    ENV.delete("SHAINET_DISABLE_CUDA")
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1152,7 +1152,7 @@ module SHAInet
 
             # Get the transformer's d_model dimension from layer size
             d_model = @transformer_layers.first.size
-            seq_len = 16 # hardcoded for now, should be dynamic
+            seq_len = input_matrix.rows
 
             if grad.rows == 1 && grad.cols != d_model
               # We have output gradients (1 x vocab_size), need to transform to (seq_len x d_model)

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -337,6 +337,8 @@ module SHAInet
       rows = x.rows
       cols = x.cols
 
+      raise ArgumentError.new("size mismatch") unless d_out.rows == rows && d_out.cols == cols
+
       # Ensure workspaces exist (in case forward fell back to CPU earlier)
       ensure_workspace_matrices(rows, cols) if @workspace_d_x.nil?
 
@@ -425,6 +427,8 @@ module SHAInet
       x = @x.as(SimpleMatrix)
       rows = x.rows
       cols = x.cols
+
+      raise ArgumentError.new("size mismatch") unless d_out.rows == rows && d_out.cols == cols
 
       # Use CPU matrices for computation
       d_gamma = SimpleMatrix.zeros(1, cols)


### PR DESCRIPTION
## Summary
- enforce gradient size checks in `LayerNorm#backward`
- fix transformer gradient expansion to use actual sequence length
- add spec for mismatched gradient shape on CPU and GPU

## Testing
- `crystal spec --error-trace spec/layer_norm_shape_spec.cr`
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_686e76ce13d08331bfaeb07b81c94124