### PR TITLE
Add INT8 quantization example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ Enable weight decay to shrink parameters on each update:
 net.weight_decay = 0.01
 ```
 
+### INT8 Quantization
+
+Convert a trained network to use INT8 weights for faster inference:
+
+```crystal
+net.quantize_int8!
+net.precision = SHAInet::Precision::Int8
+puts net.run([1.0, 0.0])
+```
+
+See `examples/quantize_int8.cr` for a full example.
+
 ---
 
 ## Advanced

--- a/examples/quantize_int8.cr
+++ b/examples/quantize_int8.cr
@@ -1,0 +1,37 @@
+require "../src/shainet"
+
+# Demonstration of INT8 quantization and inference
+ENV["SHAINET_DISABLE_CUDA"] = "1"
+
+# XOR training data
+DATA = [
+  [[0.0, 0.0], [0.0]],
+  [[1.0, 0.0], [1.0]],
+  [[0.0, 1.0], [1.0]],
+  [[1.0, 1.0], [0.0]],
+]
+
+# Build a tiny network
+net = SHAInet::Network.new
+net.add_layer(:input, 2, SHAInet.sigmoid)
+net.add_layer(:hidden, 2, SHAInet.sigmoid)
+net.add_layer(:output, 1, SHAInet.sigmoid)
+net.fully_connect
+
+# Train in full precision
+net.train(
+  data: DATA,
+  training_type: :sgdm,
+  cost_function: :mse,
+  epochs: 5000,
+  log_each: 1000
+)
+
+# Inference before quantization
+puts "Full precision output: #{net.run([1.0, 0.0])[0]}"
+
+# Quantize weights and switch to INT8 inference
+net.quantize_int8!
+net.precision = SHAInet::Precision::Int8
+
+puts "INT8 output: #{net.run([1.0, 0.0])[0]}"

--- a/spec/int8_quantization_spec.cr
+++ b/spec/int8_quantization_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+
+describe "INT8 quantization" do
+  it "preserves accuracy within tolerance" do
+    ENV["SHAINET_DISABLE_CUDA"] = "1"
+    Random::DEFAULT.new_seed(42_u64)
+
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2, SHAInet.none)
+    net.add_layer(:output, 1, SHAInet.sigmoid)
+    net.fully_connect
+
+    layer = net.output_layers.last
+    layer.weights[0, 0] = -0.05
+    layer.weights[1, 0] = 0.05
+    layer.biases[0, 0] = 0.0
+
+    out_fp = net.run([0.5, -0.5])
+
+    net.quantize_int8!
+    net.precision = SHAInet::Precision::Int8
+    out_int8 = net.run([0.5, -0.5])
+
+    out_int8.first.should be_close(out_fp.first, 1e-3)
+  end
+end


### PR DESCRIPTION
## Summary
- test INT8 inference accuracy via `quantize_int8!`
- provide an example script for quantization
- document INT8 quantization usage

## Testing
- `crystal spec`


------
https://chatgpt.com/codex/tasks/task_e_686eb7ef01c88331b8983a5a016563c8