### PR TITLE
Add half precision gemm_ex support

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -39,6 +39,18 @@ module SHAInet
       false
     end
 
+    def gemm_ex_available? : Bool
+      false
+    end
+
+    def data_type_for(*args)
+      raise "CUDA disabled"
+    end
+
+    def compute_type_for(*args)
+      raise "CUDA disabled"
+    end
+
     def malloc(*args) : Int32
       raise "CUDA disabled"
     end


### PR DESCRIPTION
## Summary
- map Precision::Fp16 and Precision::Bf16 to cuBLAS datatypes and compute types
- expose CUDA.gemm_ex_available? with runtime detection
- adjust cuda_stub to provide the new helpers when CUDA is disabled
- use gemm_ex for half precision matrix multiplication with CPU fallbacks

## Testing
- `crystal spec --no-color`


------
https://chatgpt.com/codex/tasks/task_e_686eb7fc0e608331abf43bc179d46d56