### PR TITLE
Improve SimpleMatrix mixed precision handling

### DIFF
--- a/spec/simple_matrix_precision_spec.cr
+++ b/spec/simple_matrix_precision_spec.cr
@@ -1,0 +1,35 @@
+require "./spec_helper"
+
+describe SHAInet::SimpleMatrix do
+  it "handles Float16 operations" do
+    a = SHAInet::SimpleMatrix.from_a([[1.5, 2.5], [3.0, -4.5]], SHAInet::Precision::Fp16)
+    b = SHAInet::SimpleMatrix.from_a([[0.5, -2.5], [1.0, 1.5]], SHAInet::Precision::Fp16)
+
+    sum = a + b
+    sum[0, 0].should be_close(2.0, 0.01)
+    sum[1, 1].should be_close(-3.0, 0.01)
+
+    diff = a - b
+    diff[0, 1].should be_close(5.0, 0.01)
+
+    prod = a * b.transpose
+    prod[0, 0].should be_close(1.5*0.5 + 2.5*(-2.5), 0.01)
+
+    t = a.transpose
+    t[1, 0].should be_close(2.5, 0.01)
+  end
+
+  it "handles BFloat16 operations" do
+    a = SHAInet::SimpleMatrix.from_a([[1.25, -3.5]], SHAInet::Precision::Bf16)
+    b = SHAInet::SimpleMatrix.from_a([[0.75, 2.0]], SHAInet::Precision::Bf16)
+
+    sum = a + b
+    sum[0, 0].should be_close(2.0, 0.01)
+
+    diff = a - b
+    diff[0, 1].should be_close(-5.5, 0.01)
+
+    prod = a * b.transpose
+    prod[0, 0].should be_close(1.25*0.75 + (-3.5)*2.0, 0.01)
+  end
+end


### PR DESCRIPTION
## Summary
- support Float16/BFloat16 arithmetic in SimpleMatrix by doing math in float32 when needed
- test elementwise ops on low precision matrices

## Testing
- `SHAINET_DISABLE_CUDA=1 crystal spec spec/simple_matrix_spec.cr spec/simple_matrix_precision_spec.cr -v`

------
https://chatgpt.com/codex/tasks/task_e_686ec04fe0b48331b1d32459769f7989