### PR TITLE
Fix pointer types for CUDA specs

### DIFF
--- a/spec/softmax_cross_entropy_label_cuda_spec.cr
+++ b/spec/softmax_cross_entropy_label_cuda_spec.cr
@@ -45,9 +45,9 @@ describe "CUDA softmax cross entropy with labels" do
     {% if flag?(:enable_cuda) %}
       # Call the CUDA kernel directly, not via CUDNN wrapper
       SHAInet::CUDA.softmax_cross_entropy_label(
-        g_pred.device_ptr.not_nil!,
+        g_pred.device_ptr.not_nil!.as(Pointer(Float64)),
         labels_dev,
-        grad.device_ptr.not_nil!,
+        grad.device_ptr.not_nil!.as(Pointer(Float64)),
         pointerof(loss_val),
         g_pred.rows,
         g_pred.cols

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -692,7 +692,7 @@ module SHAInet
           input.sync_to_device!("cudnn_element_log_in") unless input.device_dirty?
           output.sync_to_device!("cudnn_element_log_out") unless output.device_dirty?
           size = input.rows * input.cols
-          CUDA.element_log(out_ptr, in_ptr, size)
+          CUDA.element_log(out_ptr.as(Pointer(Float64)), in_ptr.as(Pointer(Float64)), size)
           output.mark_device_dirty!
           return
         rescue e


### PR DESCRIPTION
## Summary
- cast device pointers to `Pointer(Float64)` in CUDA softmax cross entropy spec
- cast CudaMatrix pointers to `Pointer(Float64)` for element_log kernel

## Testing
- `crystal spec -Denable_cuda` *(fails: cannot find `-lcublas` and `-lcudart`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec6ac07f4833191fcd476dfbd8429