### PR TITLE
Support half precision data conversion

### DIFF
--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -49,7 +49,7 @@ require "./shainet/version"
 
 module SHAInet
   Log = ::Log.for(self)
-  alias GenNum = Float64 | Int32 | Int64 | Float32
+  alias GenNum = Float64 | Int32 | Int64 | Float32 | Float16 | BFloat16
 
   lvl = {
     "info"  => ::Log::Severity::Info,

--- a/src/shainet/data/data.cr
+++ b/src/shainet/data/data.cr
@@ -114,9 +114,9 @@ module SHAInet
     end
 
     def normalize(x, xmin, xmax)
-      range = xmax - xmin
+      range = xmax.to_f64 - xmin.to_f64
       return @ymax.to_f64 if range == 0
-      adj_x = x.to_f64 - (xmin + @ymin)
+      adj_x = x.to_f64 - (xmin.to_f64 + @ymin)
       norm = (@yrange / range)
       value = adj_x * norm
       return 0.0 if value.nan?
@@ -132,10 +132,10 @@ module SHAInet
     end
 
     def denormalize(x, xmin, xmax)
-      range = xmax - xmin
+      range = xmax.to_f64 - xmin.to_f64
       return xmin.to_f64 if range == 0
       denorm = x.to_f64 * (range / @yrange)
-      adj_x = @ymin + xmin
+      adj_x = @ymin + xmin.to_f64
       value = denorm + adj_x
       return 0.0 if value.nan?
       value

--- a/src/shainet/math/functions.cr
+++ b/src/shainet/math/functions.cr
@@ -44,34 +44,40 @@ module SHAInet
   # # Activation functions # #
 
   def self._sigmoid(value : GenNum) : Float64 # Output range (0..1)
-    (1.0/(1.0 + Math::E**(-value))).to_f64
+    v = value.to_f64
+    (1.0/(1.0 + Math::E**(-v))).to_f64
   end
 
   def self._bp_sigmoid(value : GenNum) : Float64 # Output range (-1..1)
-    ((1.0 - Math::E**(-value))/(1.0 + Math::E**(-value))).to_f64
+    v = value.to_f64
+    ((1.0 - Math::E**(-v))/(1.0 + Math::E**(-v))).to_f64
   end
 
   def self._log_sigmoid(value : GenNum) : Float64 # Output range (0..1)
-    ((Math::E**(value))/(1.0 + Math::E**(value))).to_f64
+    v = value.to_f64
+    ((Math::E**(v))/(1.0 + Math::E**(v))).to_f64
   end
 
   def self._tanh(value : GenNum) : Float64 # Output range (-1..1)
-    ((Math::E**(value) - Math::E**(-value))/(Math::E**(value) + Math::E**(-value))).to_f64
+    v = value.to_f64
+    ((Math::E**(v) - Math::E**(-v))/(Math::E**(v) + Math::E**(-v))).to_f64
   end
 
   def self._relu(value : GenNum) # Output range (0..inf)
-    if value < 0
-      (0).to_f64
+    v = value.to_f64
+    if v < 0
+      0.0
     else
-      value.to_f64
+      v
     end
   end
 
   def self._l_relu(value : GenNum, slope : Float64 = 0.01) : Float64 # Output range (-inf..inf)
-    if value < 0
-      slope.to_f64*value.to_f64
+    v = value.to_f64
+    if v < 0
+      slope.to_f64 * v
     else
-      value.to_f64
+      v
     end
   end
 
@@ -113,11 +119,13 @@ module SHAInet
   end
 
   def self._bp_sigmoid_prime(value : GenNum) : Float64
-    (2*Math::E**(value)/(Math::E**(value) + 1)**2).to_f64
+    v = value.to_f64
+    (2 * Math::E**(v) / (Math::E**(v) + 1)**2).to_f64
   end
 
   def self._log_sigmoid_prime(value : GenNum) : Float64
-    (Math::E**(value)/(Math::E**(value) + 1)**2).to_f64
+    v = value.to_f64
+    (Math::E**(v) / (Math::E**(v) + 1)**2).to_f64
   end
 
   def self._tanh_prime(value : GenNum) : Float64
@@ -125,18 +133,20 @@ module SHAInet
   end
 
   def self._relu_prime(value : GenNum) : Float64
-    if value < 0
-      (0).to_f64
+    v = value.to_f64
+    if v < 0
+      0.0
     else
-      (1).to_f64
+      1.0
     end
   end
 
   def self._l_relu_prime(value : GenNum, slope : Float64 = 0.01) : Float64
-    if value < 0
+    v = value.to_f64
+    if v < 0
       slope
     else
-      (1).to_f64
+      1.0
     end
   end
 


### PR DESCRIPTION
## Summary
- allow Float16/BFloat16 inputs in GenNum
- map numbers to half-precision types in `convert_num`
- construct matrices in the network using the network precision
- adjust workspace creation for precision
- update data normalization and activation helpers to operate on half-precision values

## Testing
- `crystal spec` *(fails: INT8 quantization preserves accuracy within tolerance)*

------
https://chatgpt.com/codex/tasks/task_e_686ecf0efd1883319b2c931e8fba99d0