### PR TITLE
Add network attribute serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,36 @@ puts net.run([1.0, 0.0])
 
 See `examples/quantize_int8.cr` for a full example.
 
+### Saving and Loading Networks
+
+Networks can be serialized to JSON with global parameters included:
+
+```crystal
+net.save_to_file("model.json")
+
+other = SHAInet::Network.new
+other.load_from_file("model.json")
+```
+
+The JSON contains training attributes and residual connections:
+
+```json
+{
+  "learning_rate": 0.005,
+  "momentum": 0.05,
+  "precision": "Fp64",
+  "warmup_steps": 0,
+  "decay_type": null,
+  "decay_rate": 0.0,
+  "decay_step": 1,
+  "residual_edges": {"1": [0]},
+  "layers": [
+    {"l_type": "input", "weights": [[...]], "biases": [...], "activation_function": "sigmoid"},
+    {"l_type": "output", "weights": [[...]], "biases": [...], "activation_function": "sigmoid"}
+  ]
+}
+```
+
 ---
 
 ## Advanced

--- a/spec/network_save_load_spec.cr
+++ b/spec/network_save_load_spec.cr
@@ -1,0 +1,42 @@
+require "./spec_helper"
+
+describe SHAInet::Network do
+  it "saves and loads network with attributes" do
+    ENV["SHAINET_DISABLE_CUDA"] = "1"
+    net = SHAInet::Network.new
+    net.add_layer(:input, 2, SHAInet.sigmoid)
+    net.add_layer(:hidden, 2, SHAInet.sigmoid)
+    net.add_layer(:hidden, 2, SHAInet.sigmoid)
+    net.add_layer(:output, 1, SHAInet.sigmoid)
+    net.fully_connect
+    net.add_residual(0, 1)
+    net.learning_rate = 0.01
+    net.momentum = 0.9
+    net.precision = SHAInet::Precision::Fp32
+    net.warmup_steps = 5
+    net.decay_type = :step
+    net.decay_rate = 0.5
+    net.decay_step = 2
+
+    input = [0.2, -0.1]
+    out1 = net.run(input)
+
+    path = "/tmp/test_net.json"
+    net.save_to_file(path)
+
+    net2 = SHAInet::Network.new
+    net2.load_from_file(path)
+    out2 = net2.run(input)
+
+    out2.size.should eq(out1.size)
+    out2.first.should be_close(out1.first, 1e-6)
+    net2.learning_rate.should eq(net.learning_rate)
+    net2.momentum.should eq(net.momentum)
+    net2.precision.should eq(net.precision)
+    net2.warmup_steps.should eq(net.warmup_steps)
+    net2.decay_type.should eq(net.decay_type)
+    net2.decay_rate.should eq(net.decay_rate)
+    net2.decay_step.should eq(net.decay_step)
+    net2.residual_edges.should eq(net.residual_edges)
+  end
+end


### PR DESCRIPTION
## Summary
- extend `Network#save_to_file` to write global attributes
- restore attributes in `Network#load_from_file`
- document saving/loading and new JSON structure
- test saving and loading a network

## Testing
- `crystal spec spec/network_save_load_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_686f6aa80000833185a755c61b553104