### PR TITLE
Add CUDA device management helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ and reuse them across iterations. Call `to_gpu!` or `to_cpu!` only when
 switching devices. Repeated calls without a device change keep the existing
 workspaces to avoid unnecessary allocations.
 
+Use `SHAInet::CUDA.device_count` to query the available GPUs and
+`SHAInet::CUDA.set_device(id)` to select which GPU to use before creating
+matrices:
+
+```crystal
+if SHAInet::CUDA.device_count > 1
+  SHAInet::CUDA.set_device(1) # choose second GPU
+end
+```
+
 ---
 
 ## Usage

--- a/spec/cuda_device_selection_spec.cr
+++ b/spec/cuda_device_selection_spec.cr
@@ -1,0 +1,13 @@
+require "./spec_helper"
+
+describe "CUDA device selection" do
+  it "sets active device when multiple GPUs exist" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    count = SHAInet::CUDA.device_count
+    pending! "only one GPU" unless count > 1
+
+    SHAInet::CUDA.set_device(0).should eq(0)
+    SHAInet::CUDA.set_device(1).should eq(0)
+  end
+end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -19,6 +19,8 @@ module SHAInet
       fun cudaMallocHost(ptr : Pointer(Pointer(Void)), size : LibC::SizeT) : Int32
       fun cudaFreeHost(ptr : Pointer(Void)) : Int32
       fun cudaMemGetInfo(free : Pointer(LibC::SizeT), total : Pointer(LibC::SizeT)) : Int32
+      fun cudaGetDeviceCount(count : Pointer(Int32)) : Int32
+      fun cudaSetDevice(device : Int32) : Int32
     end
 
     @[Link("cublas")]
@@ -230,6 +232,27 @@ module SHAInet
     rescue e
       Log.error { "kernel availability check raised: #{e}" }
       false
+    end
+
+    # Returns the number of CUDA-capable devices or 0 when unavailable
+    def device_count : Int32
+      return 0 unless available?
+      count = 0
+      if LibCUDARuntime.cudaGetDeviceCount(pointerof(count)) == 0
+        count
+      else
+        0
+      end
+    rescue
+      0
+    end
+
+    # Select the active CUDA device by id. Returns CUDA error code.
+    def set_device(id : Int32) : Int32
+      return -1 unless available?
+      LibCUDARuntime.cudaSetDevice(id)
+    rescue
+      -1
     end
 
     def malloc(ptr : Pointer(Pointer(Void)), size : LibC::SizeT)

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -39,6 +39,14 @@ module SHAInet
       false
     end
 
+    def device_count : Int32
+      0
+    end
+
+    def set_device(*args) : Int32
+      raise "CUDA disabled"
+    end
+
     def gemm_ex_available? : Bool
       false
     end


### PR DESCRIPTION
## Summary
- expose cudaGetDeviceCount and cudaSetDevice bindings
- add `SHAInet::CUDA.device_count` and `.set_device`
- document selecting a GPU before training
- test device selection logic

## Testing
- `crystal spec --order random` *(fails: INT8 quantization and cached inference specs)*

------
https://chatgpt.com/codex/tasks/task_e_686f6f360b088331acbc04b1ef98d2be