### PR TITLE
Track CUDA device ownership for matrices

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -20,6 +20,7 @@ module SHAInet
       fun cudaFreeHost(ptr : Pointer(Void)) : Int32
       fun cudaMemGetInfo(free : Pointer(LibC::SizeT), total : Pointer(LibC::SizeT)) : Int32
       fun cudaGetDeviceCount(count : Pointer(Int32)) : Int32
+      fun cudaGetDevice(device : Pointer(Int32)) : Int32
       fun cudaSetDevice(device : Int32) : Int32
     end
 
@@ -253,6 +254,19 @@ module SHAInet
       LibCUDARuntime.cudaSetDevice(id)
     rescue
       -1
+    end
+
+    # Return the currently active CUDA device id or nil if unavailable
+    def current_device
+      return nil unless available?
+      id = 0
+      if LibCUDARuntime.cudaGetDevice(pointerof(id)) == 0
+        id
+      else
+        nil
+      end
+    rescue
+      nil
     end
 
     def malloc(ptr : Pointer(Pointer(Void)), size : LibC::SizeT)

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -47,6 +47,10 @@ module SHAInet
       raise "CUDA disabled"
     end
 
+    def current_device
+      0
+    end
+
     def gemm_ex_available? : Bool
       false
     end

--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -439,7 +439,7 @@ module SHAInet
 
     # Convert SimpleMatrix to CudaMatrix for GPU operations
     def to_cuda : CudaMatrix
-      result = CudaMatrix.new(@rows, @cols, precision: @precision)
+      result = CudaMatrix.new(@rows, @cols, precision: @precision, device_id: CUDA.current_device || 0)
       # Use batch copy through raw data for better performance
       @rows.times do |i|
         @cols.times do |j|


### PR DESCRIPTION
## Summary
- track which CUDA device allocated each `CudaMatrix`
- expose `CUDA.current_device` and stub
- keep device info when allocating matrices via GPUMemory helpers
- ensure operations check that matrices are on the same device

## Testing
- `crystal spec --order random` *(fails: Transformer cached inference produces same output as full run and stores keys)*

------
https://chatgpt.com/codex/tasks/task_e_686f76ce617483319d8568675ba74745