### PR TITLE
Add multi-GPU docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,13 @@ help:
 	@echo ""
 	@echo "Usage:"
 	@echo "  make install                 # Complete setup (dependencies + CUDA)"
-	@echo "  make cuda                    # Build CUDA kernels only"
-	@echo "  LD_LIBRARY_PATH=. make test  # Test with library path"
-	@echo ""
-	@echo "For GPU acceleration, use 'make install' instead of 'shards install'"
+@echo "  make cuda                    # Build CUDA kernels only"
+@echo "  LD_LIBRARY_PATH=. make test  # Test with library path"
+@echo ""
+@echo "Multi-GPU example:"
+@echo "  CUDA_VISIBLE_DEVICES=0,1 crystal run my_train.cr"
+@echo ""
+@echo "For GPU acceleration, use 'make install' instead of 'shards install'"
 
 cuda: $(CUDA_LIB)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ if SHAInet::CUDA.device_count > 1
 end
 ```
 
+### Multi-GPU Training
+
+SHAInet can train on multiple GPUs using `SHAInet::DataParallelTrainer`. Ensure
+the CUDA toolkit is installed and that your system has two or more GPUs
+available.
+
+```crystal
+devices = [0, 1]
+net.train(data: data,
+  training_type: :sgd,
+  cost_function: :mse,
+  epochs: 10,
+  training_mode: :data_parallel,
+  devices: devices)
+```
+
+Use the `CUDA_VISIBLE_DEVICES` environment variable to limit the GPUs that will
+be used:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 crystal run my_train.cr
+```
+
 ---
 
 ## Usage


### PR DESCRIPTION
## Summary
- document DataParallelTrainer usage in README
- mention CUDA_VISIBLE_DEVICES environment variable
- add a short multi-GPU example to the Makefile help

## Testing
- `make test`
- `crystal spec` *(fails: SHAInet::Network saves network on interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686f822bf2a483318d879f45ce87375c