### PR TITLE
Add half precision CUDA paths

### DIFF
--- a/spec/cuda_dropout_inplace_spec.cr
+++ b/spec/cuda_dropout_inplace_spec.cr
@@ -4,7 +4,7 @@ describe "CUDA dropout! in-place" do
   it "masks values on the GPU" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
 
-    mat = SHAInet::CudaMatrix.new(32, 32)
+    mat = SHAInet::CudaMatrix.new(32, 32, 0.0, SHAInet::Precision::Fp16)
     mat.fill!(1.0)
 
     # Apply dropout in-place without CPU sync

--- a/spec/cuda_softmax_dropout_spec.cr
+++ b/spec/cuda_softmax_dropout_spec.cr
@@ -4,7 +4,7 @@ describe "CUDA softmax and dropout" do
   it "matches CPU softmax" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
     cpu = SHAInet::SimpleMatrix.from_a([[1.0, 2.0], [3.0, 4.0]])
-    gpu = SHAInet::GPUMemory.to_gpu(cpu)
+    gpu = SHAInet::CudaMatrix.from_a(cpu.to_a, SHAInet::Precision::Fp16)
     gpu_out = SHAInet.softmax_rows(gpu)
     gpu_out.sync_from_device! if gpu_out.is_a?(SHAInet::CudaMatrix)
     cpu_out = SHAInet.softmax_rows(cpu)
@@ -17,7 +17,7 @@ describe "CUDA softmax and dropout" do
 
   it "drops approximately the given percentage" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    mat = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(10, 10))
+    mat = SHAInet::CudaMatrix.ones(10, 10, SHAInet::Precision::Fp16)
     runs = 200
     total_ratio = 0.0
     runs.times do |run_idx|

--- a/spec/embedding_cuda_lookup_spec.cr
+++ b/spec/embedding_cuda_lookup_spec.cr
@@ -6,6 +6,16 @@ describe "Embedding GPU lookup" do
 
     # Create a simple embedding layer with fixed values
     layer = SHAInet::EmbeddingLayer.new(5, 4)
+    if layer.embeddings.is_a?(SHAInet::CudaMatrix)
+      fp16 = SHAInet::CudaMatrix.new(5, 4, 0.0, SHAInet::Precision::Fp16)
+      5.times do |r|
+        4.times do |c|
+          fp16[r, c] = layer.embeddings[r, c]
+        end
+      end
+      layer.embeddings = fp16
+      layer.gradients = SHAInet::CudaMatrix.zeros(5, 4, SHAInet::Precision::Fp16)
+    end
 
     # Set the embedding values
     token_id = 1

--- a/spec/layer_norm_cuda_parity_spec.cr
+++ b/spec/layer_norm_cuda_parity_spec.cr
@@ -29,8 +29,8 @@ describe "LayerNorm GPU parity" do
       gpu_ln.beta[0, j] = cpu_ln.beta[0, j]
     end
 
-    x_gpu = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a(data))
-    dout_gpu = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a(dout_data))
+    x_gpu = SHAInet::CudaMatrix.from_a(data, SHAInet::Precision::Fp16)
+    dout_gpu = SHAInet::CudaMatrix.from_a(dout_data, SHAInet::Precision::Fp16)
 
     out_gpu = gpu_ln.forward(x_gpu)
     out_gpu.sync_from_device! if out_gpu.is_a?(SHAInet::CudaMatrix)


### PR DESCRIPTION
## Summary
- dispatch dropout kernels based on matrix precision
- use FP16/BF16 kernels for softmax and dropout
- allocate embedding workspaces with correct precision and gather rows using precision-aware kernels
- call precision-specific layer norm kernels
- test half precision paths in dropout, softmax, embedding lookups, and layer norm

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686f8d6962748331987ded9ee281ac86