### PR TITLE
Fix tensor descriptor strides and add cuDNN test

### DIFF
--- a/spec/cudnn_descriptor_spec.cr
+++ b/spec/cudnn_descriptor_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+# Basic test to ensure tensor descriptor creation works with cuDNN
+# by performing a simple activation using the helper.
+describe "cuDNN descriptor" do
+  it "performs an activation without errors" do
+    pending! "cuDNN not available" unless SHAInet::CUDA.cudnn_available?
+
+    input = SHAInet::CudaMatrix.new(2, 3, 1.0)
+    output = SHAInet::CudaMatrix.new(2, 3, 0.0)
+
+    # Uses create_tensor_descriptor_2d internally
+    SHAInet::CUDNN.sigmoid_forward!(output, input)
+
+    output.sync_from_device!
+    expected = 1.0 / (1.0 + Math.exp(-1.0))
+
+    output.rows.times do |i|
+      output.cols.times do |j|
+        output[i, j].should be_close(expected, 1e-6)
+      end
+    end
+  end
+end

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -244,7 +244,9 @@ module SHAInet
 
       # Set up 4D tensor descriptor: [batch, channels, height, width] = [rows, cols, 1, 1]
       dims = [rows, cols, 1, 1]
-      strides = [cols, 1, cols, cols] # Row-major ordering
+      # Row-major ordering for a 2D matrix treated as [rows, cols, 1, 1]
+      # For singleton dimensions (height and width) the stride can be 1
+      strides = [cols, 1, 1, 1]
       CUDNN.check_status(LibCUDNN.cudnnSetTensorNdDescriptor(
         desc,
         data_type_for(precision),


### PR DESCRIPTION
## Summary
- correct strides for 2D tensor descriptors in `cudnn.cr`
- add spec verifying descriptor initialization via cuDNN activation

## Testing
- `crystal spec spec/cudnn_descriptor_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_686fb9366aac83319fc816265c694682