### PR TITLE
Add precision-aware workspace allocation

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1174,10 +1174,12 @@ module SHAInet
     end
 
     # Get a matrix from the pool or create a new one
-    def self.get_workspace(rows : Int32, cols : Int32, source : String = "workspace") : CudaMatrix
-      return new(rows, cols) unless @@pool_enabled
+    def self.get_workspace(rows : Int32, cols : Int32,
+                           source : String = "workspace",
+                           precision : Precision = Precision::Fp64) : CudaMatrix
+      return new(rows, cols, precision: precision) unless @@pool_enabled
 
-      key = "#{rows}x#{cols}"
+      key = "#{rows}x#{cols}_#{precision}"
       pool = @@matrix_pool[key]
 
       if matrix = pool.pop?
@@ -1186,7 +1188,7 @@ module SHAInet
         matrix
       else
         # Create new matrix
-        new(rows, cols)
+        new(rows, cols, precision: precision)
       end
     end
 
@@ -1194,7 +1196,7 @@ module SHAInet
     def self.return_workspace(matrix : CudaMatrix)
       return unless @@pool_enabled
 
-      key = "#{matrix.rows}x#{matrix.cols}"
+      key = "#{matrix.rows}x#{matrix.cols}_#{matrix.precision}"
       pool = @@matrix_pool[key]
 
       # Only pool if we haven't exceeded the limit

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -294,11 +294,7 @@ module SHAInet
         end
 
         precision = @embeddings.as(CudaMatrix).precision
-        @workspace_result = if precision == Precision::Fp64
-                              CudaMatrix.get_workspace(ids_size, @l_size, "embed_ws")
-                            else
-                              CudaMatrix.new(ids_size, @l_size, 0.0, precision)
-                            end
+        @workspace_result = CudaMatrix.get_workspace(ids_size, @l_size, "embed_ws", precision)
         @workspace_result.not_nil!.zero!
 
         @last_ids_size = ids_size

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -200,33 +200,13 @@ module SHAInet
           CudaMatrix.return_workspace(ws)
         end
 
-        @workspace_mean = if precision == Precision::Fp64
-                            CudaMatrix.get_workspace(batch_size, 1, "ln_mean")
-                          else
-                            CudaMatrix.new(batch_size, 1, 0.0, Precision::Fp32)
-                          end
-        @workspace_var = if precision == Precision::Fp64
-                           CudaMatrix.get_workspace(batch_size, 1, "ln_var")
-                         else
-                           CudaMatrix.new(batch_size, 1, 0.0, Precision::Fp32)
-                         end
-        @workspace_norm = if precision == Precision::Fp64
-                             CudaMatrix.get_workspace(batch_size, d_model, "ln_norm")
-                           else
-                             CudaMatrix.new(batch_size, d_model, 0.0, precision)
-                           end
-        @workspace_result = if precision == Precision::Fp64
-                               CudaMatrix.get_workspace(batch_size, d_model, "ln_result")
-                             else
-                               CudaMatrix.new(batch_size, d_model, 0.0, precision)
-                             end
-        @workspace_d_x = if precision == Precision::Fp64
-                            CudaMatrix.get_workspace(batch_size, d_model, "ln_d_x")
-                          else
-                            CudaMatrix.new(batch_size, d_model, 0.0, precision)
-                          end
-        @workspace_d_gamma = CudaMatrix.get_workspace(1, d_model, "ln_d_gamma")
-        @workspace_d_beta = CudaMatrix.get_workspace(1, d_model, "ln_d_beta")
+        @workspace_mean = CudaMatrix.get_workspace(batch_size, 1, "ln_mean", precision)
+        @workspace_var = CudaMatrix.get_workspace(batch_size, 1, "ln_var", precision)
+        @workspace_norm = CudaMatrix.get_workspace(batch_size, d_model, "ln_norm", precision)
+        @workspace_result = CudaMatrix.get_workspace(batch_size, d_model, "ln_result", precision)
+        @workspace_d_x = CudaMatrix.get_workspace(batch_size, d_model, "ln_d_x", precision)
+        @workspace_d_gamma = CudaMatrix.get_workspace(1, d_model, "ln_d_gamma", precision)
+        @workspace_d_beta = CudaMatrix.get_workspace(1, d_model, "ln_d_beta", precision)
 
         @workspace_d_gamma.not_nil!.zero!
         @workspace_d_beta.not_nil!.zero!


### PR DESCRIPTION
## Summary
- allow specifying precision when requesting workspace matrices
- pass precision everywhere workspaces are allocated
- simplify embedding and layer norm workspace creation

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686fbd25c32c83318e020ae76f9377e7