### PR TITLE
Check precision before CUDA bias add

### DIFF
--- a/spec/cuda_matrix_spec.cr
+++ b/spec/cuda_matrix_spec.cr
@@ -34,4 +34,16 @@ describe SHAInet::CudaMatrix do
     matrix[1, 0].should eq(0.0 + 1.0)
     matrix[1, 1].should eq(4.0 + 1.0)
   end
+
+  it "raises error for non-Fp64 precision when cuDNN is unavailable" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+    pending! "cuDNN available" if SHAInet::CUDNN.available?
+
+    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+    bias = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
+
+    expect_raises(Exception, /non-FP64 precisions require cuDNN/) do
+      matrix.add_bias!(bias)
+    end
+  end
 end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -789,7 +789,13 @@ module SHAInet
         end
       end
 
-      # Fallback to CUDA kernel
+      # Fallback to CUDA kernel. This kernel only supports Float64 precision,
+      # so ensure both matrices are FP64 before proceeding. Non-FP64 precisions
+      # must rely on cuDNN for bias addition, otherwise memory faults may occur.
+      unless self.precision == Precision::Fp64 && bias.precision == Precision::Fp64
+        raise "CUDA fallback for add_bias! only supports Precision::Fp64; non-FP64 precisions require cuDNN"
+      end
+
       raise RuntimeError.new("GPU add_bias! requires valid device pointers") unless (dptr = self.device_ptr) && (bptr = bias.device_ptr) && !dptr.null? && !bptr.null?
 
       # Ensure both matrices have up-to-date GPU data


### PR DESCRIPTION
## Summary
- prevent non-FP64 precision matrices from using CUDA fallback in `CudaMatrix#add_bias!`
- document limitation and raise descriptive error
- test that CUDA fallback fails gracefully when precision mismatches

## Testing
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_686fc3be494c83318104911046b02d38