### PR TITLE
Update mul_row_vector precision handling

### DIFF
--- a/spec/cuda_mul_row_vector_spec.cr
+++ b/spec/cuda_mul_row_vector_spec.cr
@@ -1,0 +1,27 @@
+require "./spec_helper"
+
+describe "CudaMatrix mul_row_vector!" do
+  it "multiplies columns for Fp16 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+    a = SHAInet::CudaMatrix.from_a([[1.0, 2.0], [3.0, 4.0]], SHAInet::Precision::Fp16)
+    v = SHAInet::CudaMatrix.from_a([[2.0, 3.0]], SHAInet::Precision::Fp16)
+    a.mul_row_vector!(v)
+    a.sync_from_device!
+    a[0,0].should be_close(2.0, 0.01)
+    a[0,1].should be_close(6.0, 0.01)
+    a[1,0].should be_close(6.0, 0.01)
+    a[1,1].should be_close(12.0, 0.01)
+  end
+
+  it "multiplies columns for Fp32 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+    a = SHAInet::CudaMatrix.from_a([[1.0, 2.0], [3.0, 4.0]], SHAInet::Precision::Fp32)
+    v = SHAInet::CudaMatrix.from_a([[0.5, 1.5]], SHAInet::Precision::Fp32)
+    a.mul_row_vector!(v)
+    a.sync_from_device!
+    a[0,0].should be_close(0.5, 1e-6)
+    a[0,1].should be_close(3.0, 1e-6)
+    a[1,0].should be_close(1.5, 1e-6)
+    a[1,1].should be_close(6.0, 1e-6)
+  end
+end


### PR DESCRIPTION
## Summary
- check matrix precision in `mul_row_vector!`
- use cuDNN broadcast multiply for Fp16/Bf16/Fp32
- fallback to CPU when CUDA kernels aren't suitable
- add tests for Fp16 and Fp32 row-wise multiplication

## Testing
- `crystal spec spec/cuda_mul_row_vector_spec.cr --error-trace`
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686fd2284004833185b2f0d7f2ba0b9d