### PR TITLE
Ensure TrainingData respects precision on GPU

### DIFF
--- a/spec/preload_gpu_precision_spec.cr
+++ b/spec/preload_gpu_precision_spec.cr
@@ -1,0 +1,44 @@
+require "./spec_helper"
+
+describe "TrainingData GPU preload precision" do
+  it "matches network precision during training" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    inputs = [
+      [0.0, 0.0],
+      [0.0, 1.0],
+      [1.0, 0.0],
+      [1.0, 1.0],
+    ]
+    outputs = [
+      [0.0],
+      [1.0],
+      [1.0],
+      [0.0],
+    ]
+
+    data = SHAInet::TrainingData.new(inputs, outputs, preload_gpu: true)
+    data.normalize_min_max
+
+    net = SHAInet::Network.new
+    net.precision = SHAInet::Precision::Fp16
+    net.add_layer(:input, 2, SHAInet.sigmoid)
+    net.add_layer(:output, 1, SHAInet.sigmoid)
+    net.fully_connect
+
+    net.train(
+      data: data,
+      training_type: :sgd,
+      cost_function: :mse,
+      epochs: 1,
+      mini_batch_size: 2,
+      log_each: 2
+    )
+
+    pair = data.data.first
+    input = pair[0].as(SHAInet::CudaMatrix)
+    output = pair[1].as(SHAInet::CudaMatrix)
+    input.precision.should eq(net.precision)
+    output.precision.should eq(net.precision)
+  end
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -878,7 +878,7 @@ module SHAInet
 
       stream = data.is_a?(SHAInet::StreamingData) ? data : nil
       if data.is_a?(SHAInet::TrainingData) && data.preload_gpu? && CUDA.fully_available?
-        data.preload_gpu!
+        data.preload_gpu!(self.precision)
       end
       # Convert TrainingData to raw data array
       raw_data = if data.is_a?(SHAInet::TrainingData)


### PR DESCRIPTION
## Summary
- support precision parameter for `TrainingData#preload_gpu!`
- use network precision when preloading GPU data in training
- add regression spec to verify dataset precision matches network

## Testing
- `crystal spec spec/preload_gpu_precision_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_686fd2cf51848331917adb692cfba429