### PR TITLE
Add precision check for cudnn add_bias!

### DIFF
--- a/spec/cudnn_add_bias_spec.cr
+++ b/spec/cudnn_add_bias_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+describe "CUDNN.add_bias!" do
+  it "raises on precision mismatch" do
+    pending! "cuDNN not available" unless SHAInet::CUDA.cudnn_available?
+
+    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+    bias = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+
+    expect_raises(ArgumentError, /matrix precision.*bias precision/) do
+      SHAInet::CUDNN.add_bias!(matrix, bias)
+    end
+  end
+end

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -385,6 +385,9 @@ module SHAInet
     # Optimized bias addition
     def self.add_bias!(matrix : CudaMatrix, bias : CudaMatrix)
       raise "Bias must be a row vector" unless bias.rows == 1 && bias.cols == matrix.cols
+      if matrix.precision != bias.precision
+        raise ArgumentError.new("matrix precision (#{matrix.precision}) must match bias precision (#{bias.precision})")
+      end
 
       # For bias addition, cuDNN expects the bias to be a 4D tensor with shape [1, C, 1, 1]
       # and the matrix to be [N, C, H, W]. For 2D matrices, we treat them as [N, C, 1, 1]


### PR DESCRIPTION
## Summary
- raise an ArgumentError when `CUDNN.add_bias!` receives matrices with different precisions
- add spec verifying the new error

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_686fd6f1efb883319697341aa39c237a