### PR TITLE
Add raw_data_buffer to CudaMatrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ if SHAInet::CUDA.device_count > 1
 end
 ```
 
+### Raw data access
+
+`CudaMatrix#raw_data` provides the matrix values as an `Array(Float64)` for
+convenience.  When the matrix uses half precision or INT8 storage this method
+allocates and converts the data.  Use `CudaMatrix#raw_data_buffer` to obtain a
+writable slice of the underlying CPU buffer without conversion.  Functions such
+as `GPUMemory.to_gpu!` use this buffer when copying data.
+
 ### Multi-GPU Training
 
 SHAInet can train on multiple GPUs using `SHAInet::DataParallelTrainer`. Ensure


### PR DESCRIPTION
## Summary
- expose `CudaMatrix#raw_data_buffer` for mutable CPU access
- use the buffer in `GPUMemory.to_gpu!` writers
- update network helpers to use `unsafe_set`
- document difference between `raw_data` and `raw_data_buffer`

## Testing
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_686fde6d34ac833190756b083fcd04a9