### PR TITLE
Add precision-specific CUDA weight updates

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -55,6 +55,10 @@ module SHAInet
       false
     end
 
+    def axpy_ex_available? : Bool
+      false
+    end
+
     def data_type_for(*args)
       raise "CUDA disabled"
     end
@@ -121,6 +125,18 @@ module SHAInet
     end
 
     def axpy(*args)
+    end
+
+    def saxpy(*args)
+    end
+
+    def axpy_ex(*args)
+    end
+
+    def weight_update_fp16(*args)
+    end
+
+    def weight_update_bf16(*args)
     end
 
     def softmax_rows(*args)


### PR DESCRIPTION
## Summary
- implement per-precision GPU `weight_update!` with CUDA AXPY variants and custom kernels
- handle CPU fallback when GPU routines are unavailable
- update MatrixLayer GPU weight update for non-FP64 weight decay
- expose new CUDA wrappers and stub methods
- add fp16/bf16 weight update CUDA kernels

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_686fde890ef083319b04fbad4c97bddc