### PR TITLE
Fix GPU matrix conversion and disable cuDNN path

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1461,10 +1461,10 @@ module SHAInet
             mat.mark_device_dirty!
           end
 
-          flat_slice.each_with_index do |v, i|
-            r = i // cols
-            c = i % cols
-            mat.unsafe_set(r, c, v)
+          arr.each_with_index do |row_arr, r|
+            row_arr.as(Array).each_with_index do |val, c|
+              mat.unsafe_set(r, c, val.as(GenNum).to_f64)
+            end
           end
 
           mat.sync_to_device!("to_matrix")
@@ -1512,7 +1512,9 @@ module SHAInet
             mat.mark_device_dirty!
           end
 
-          flat_slice.each_with_index { |v, i| mat.unsafe_set(0, i, v) }
+          arr.each_with_index do |val, i|
+            mat.unsafe_set(0, i, val.as(GenNum).to_f64)
+          end
 
           mat.sync_to_device!("to_matrix")
           mat

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -896,54 +896,8 @@ module SHAInet
         return self
       elsif @precision.in?({Precision::Fp16, Precision::Bf16, Precision::Fp32}) &&
             vec.precision == @precision && CUDNN.available?
-        {% if flag?(:enable_cuda) %}
-          begin
-            # Broadcast multiply using cuDNN OpTensor
-            op_desc = uninitialized LibCUDNN::CudnnOpTensorDescriptor
-            CUDNN.check_status(LibCUDNN.cudnnCreateOpTensorDescriptor(out op_desc))
-
-            begin
-              dtype = CUDNN.data_type_for(@precision)
-              CUDNN.check_status(LibCUDNN.cudnnSetOpTensorDescriptor(
-                op_desc,
-                LibCUDNN::CudnnOpTensorOp::CUDNN_OP_TENSOR_MUL,
-                dtype,
-                0))
-
-              mat_desc = CUDNN.create_tensor_descriptor_2d(@rows, @cols, @precision)
-              vec_desc = CUDNN.create_tensor_descriptor_2d(1, vec.cols, vec.precision)
-
-              alpha1 = 1.0
-              alpha2 = 1.0
-              beta = 0.0
-
-              self.sync_to_device!("mul_row_vector") unless device_dirty?
-              vec.sync_to_device!("mul_row_vector") unless vec.device_dirty?
-
-              CUDNN.check_status(LibCUDNN.cudnnOpTensor(
-                CUDNN.handle,
-                op_desc,
-                pointerof(alpha1).as(Pointer(Void)),
-                mat_desc,
-                dptr.as(Pointer(Void)),
-                pointerof(alpha2).as(Pointer(Void)),
-                vec_desc,
-                vptr.as(Pointer(Void)),
-                pointerof(beta).as(Pointer(Void)),
-                mat_desc,
-                dptr.as(Pointer(Void))
-              ))
-
-              mark_device_dirty!
-              return self
-            ensure
-              LibCUDNN.cudnnDestroyTensorDescriptor(mat_desc)
-              LibCUDNN.cudnnDestroyTensorDescriptor(vec_desc)
-            end
-          ensure
-            LibCUDNN.cudnnDestroyOpTensorDescriptor(op_desc)
-          end
-        {% end %}
+        # cuDNN optimized path disabled due to compilation issues.
+        # Fall back to CPU implementation below.
       end
 
       # CPU fallback


### PR DESCRIPTION
## Summary
- fix undefined variable when converting arrays to matrices on GPU
- disable the cuDNN code path in `mul_row_vector!` to avoid build issues

## Testing
- `crystal spec --order=random`

------
https://chatgpt.com/codex/tasks/task_e_686fe57267a8833194bdf4a9521a7c24