### PR TITLE
Add CUDA FP32 gemm_ex branch

### DIFF
--- a/spec/cuda_gemm_fp32_spec.cr
+++ b/spec/cuda_gemm_fp32_spec.cr
@@ -26,4 +26,29 @@ describe "CUDA fp32 GEMM" do
     c[1, 0].should be_close(43.0, 1e-6)
     c[1, 1].should be_close(50.0, 1e-6)
   end
+
+  it "multiplies fp32 matrices with *" do
+    pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
+
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+
+    a[0, 0] = 1.0
+    a[0, 1] = 2.0
+    a[1, 0] = 3.0
+    a[1, 1] = 4.0
+
+    b[0, 0] = 5.0
+    b[0, 1] = 6.0
+    b[1, 0] = 7.0
+    b[1, 1] = 8.0
+
+    c = a * b
+    c.sync_from_device!
+
+    c[0, 0].should be_close(19.0, 1e-6)
+    c[0, 1].should be_close(22.0, 1e-6)
+    c[1, 0].should be_close(43.0, 1e-6)
+    c[1, 1].should be_close(50.0, 1e-6)
+  end
 end


### PR DESCRIPTION
## Summary
- enable FP32 path for CUDA GEMM operations
- add regression test for CUDA FP32 matrix multiply using `*`

## Testing
- `shards install --skip-postinstall`
- `crystal spec -Denable_cuda --order random` *(fails: expected argument #11 to 'SHAInet::CUDA.gemm_ex' to be SHAInet::CUDA::LibCUBLAS::DataType, not SHAInet::CUDA::DataType)*

------
https://chatgpt.com/codex/tasks/task_e_6870bff8a25c8331926a5d9cd02af38b