### PR TITLE
Enforce FP64 in CUDA cross-entropy

### DIFF
--- a/spec/cross_entropy_cuda_precision_spec.cr
+++ b/spec/cross_entropy_cuda_precision_spec.cr
@@ -1,0 +1,48 @@
+require "./spec_helper"
+
+describe "CUDA cross entropy precision checks" do
+  it "raises for FP32 cross_entropy_loss_gradient" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
+    loss = 0.0
+    expect_raises(ArgumentError, /Fp64/) do
+      SHAInet::CUDNN.cross_entropy_loss_gradient(pred, target, pointerof(loss), grad)
+    end
+  end
+
+  it "raises for FP16 cross_entropy_loss_and_gradient" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    loss = 0.0
+    expect_raises(ArgumentError, /Fp64/) do
+      SHAInet::CUDNN.cross_entropy_loss_and_gradient(pred, target, pointerof(loss), grad)
+    end
+  end
+
+  it "raises for FP16 softmax_cross_entropy_loss_and_gradient" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    loss = 0.0
+    expect_raises(ArgumentError, /Fp64/) do
+      SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(pred, target, pointerof(loss), grad)
+    end
+  end
+
+  it "raises for FP16 softmax_cross_entropy_label_loss_and_gradient" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    labels = SHAInet::CudaMatrix.new(1, 1, 0.0, SHAInet::Precision::Fp64)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    loss = 0.0
+    labels[0,0] = 0.0
+    expect_raises(ArgumentError, /Fp64/) do
+      SHAInet::CUDNN.softmax_cross_entropy_label_loss_and_gradient(pred, labels, pointerof(loss), grad)
+    end
+  end
+end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -1300,7 +1300,9 @@ module SHAInet
       available? && kernels_available?
     end
 
-    # Cross-entropy loss and gradient computation kernel
+    # Cross-entropy loss and gradient computation kernel.
+    # The `predicted`, `target` and `grad_output` pointers must reference
+    # `Float64` (FP64) device memory.
     def cross_entropy_loss_gradient(predicted : Pointer(Float64), target : Pointer(Float64),
                                     grad_output : Pointer(Float64), loss_output : Pointer(Float64),
                                     rows : Int32, cols : Int32) : Int32


### PR DESCRIPTION
## Summary
- raise errors when cross-entropy helpers receive non-FP64 matrices
- clarify FP64 requirement in method docs
- document requirement in CUDA pointer helper
- test that FP16/FP32 matrices raise informative errors

## Testing
- `crystal spec -Denable_cuda --order random` *(fails: expected argument #11 to 'SHAInet::CUDA.gemm_ex' to be SHAInet::CUDA::LibCUBLAS::DataType, not SHAInet::CUDA::DataType)*

------
https://chatgpt.com/codex/tasks/task_e_6870bffc61708331812368df566b7a2c