### PR TITLE
Improve cuDNN element add

### DIFF
--- a/spec/cuda_element_add_spec.cr
+++ b/spec/cuda_element_add_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+
+describe "CUDA element-wise addition" do
+  it "adds fp16 matrices" do
+    pending! "cuDNN not available" unless SHAInet::CUDNN.available?
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
+    a[0,0] = 1.0; a[0,1] = 2.0; a[1,0] = 3.0; a[1,1] = 4.0
+    b[0,0] = 4.0; b[0,1] = 3.0; b[1,0] = 2.0; b[1,1] = 1.0
+
+    result = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
+    SHAInet::CUDNN.element_add!(result, a, b)
+    result.sync_from_device!
+
+    result[0,0].should be_close(5.0, 1e-2)
+    result[0,1].should be_close(5.0, 1e-2)
+    result[1,0].should be_close(5.0, 1e-2)
+    result[1,1].should be_close(5.0, 1e-2)
+  end
+
+  it "adds bf16 matrices" do
+    pending! "cuDNN not available" unless SHAInet::CUDNN.available?
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
+    a[0,0] = 1.0; a[0,1] = 2.0; a[1,0] = 3.0; a[1,1] = 4.0
+    b[0,0] = 4.0; b[0,1] = 3.0; b[1,0] = 2.0; b[1,1] = 1.0
+
+    result = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
+    SHAInet::CUDNN.element_add!(result, a, b)
+    result.sync_from_device!
+
+    result[0,0].should be_close(5.0, 1e-2)
+    result[0,1].should be_close(5.0, 1e-2)
+    result[1,0].should be_close(5.0, 1e-2)
+    result[1,1].should be_close(5.0, 1e-2)
+  end
+end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -675,11 +675,19 @@ module SHAInet
           CUDNN.element_add!(result, self, other, 1.0, 1.0)
           return result
         rescue e : Exception
-          Log.error { "cuDNN element_add failed: #{e}, falling back to cuBLAS" }
+          if self.precision.fp64? && other.precision.fp64? && result.precision.fp64?
+            Log.error { "cuDNN element_add failed: #{e}, falling back to cuBLAS" }
+          else
+            raise e
+          end
+        end
+      else
+        unless self.precision.fp64? && other.precision.fp64? && result.precision.fp64?
+          raise "cuDNN not available - non-FP64 precisions require cuDNN"
         end
       end
 
-      # Fallback to cuBLAS GEAM
+      # Fallback to cuBLAS GEAM (only FP64)
       handle = CUDA.create_handle
       begin
         CUDA.geam(handle, ptr_a.as(Pointer(Float64)), ptr_b.as(Pointer(Float64)), result.device_ptr.not_nil!.as(Pointer(Float64)), @rows, @cols, 1.0, 1.0)
@@ -766,11 +774,19 @@ module SHAInet
           CUDNN.element_add!(self, self, other, 1.0, 1.0)
           return self
         rescue e : Exception
-          Log.error { "cuDNN element_add failed: #{e}, falling back to cuBLAS" }
+          if self.precision.fp64? && other.precision.fp64?
+            Log.error { "cuDNN element_add failed: #{e}, falling back to cuBLAS" }
+          else
+            raise e
+          end
+        end
+      else
+        unless self.precision.fp64? && other.precision.fp64?
+          raise "cuDNN not available - non-FP64 precisions require cuDNN"
         end
       end
 
-      # Fallback to cuBLAS GEAM
+      # Fallback to cuBLAS GEAM (only FP64)
       handle = CUDA.create_handle
       begin
         CUDA.geam(handle, ptr_a.as(Pointer(Float64)), ptr_b.as(Pointer(Float64)), ptr_a.as(Pointer(Float64)), @rows, @cols, 1.0, 1.0)


### PR DESCRIPTION
## Summary
- switch `element_add!` to use `cudnnOpTensor`
- create descriptors using each matrix precision
- raise when cuDNN is missing for non-FP64
- update `CudaMatrix` add operations to enforce precision checks
- test element-wise add on FP16 and BF16

## Testing
- `crystal spec spec/cuda_element_add_spec.cr`
- `crystal spec -D enable_cuda` *(fails: expected argument #11 to SHAInet::CUDA.gemm_ex to be LibCUBLAS::DataType)*

------
https://chatgpt.com/codex/tasks/task_e_6870c46bfe988331806dbac69f1aa868