### PR TITLE
Use stack allocation for cuBLAS handles

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -367,9 +367,9 @@ module SHAInet
         end
       end
 
-      handle = Pointer(LibCUBLAS::Handle).malloc(1)
-      raise "cublasCreate failed" unless LibCUBLAS.cublasCreate_v2(handle) == 0
-      handle.value
+      handle = uninitialized LibCUBLAS::Handle
+      raise "cublasCreate failed" unless LibCUBLAS.cublasCreate_v2(pointerof(handle)) == 0
+      handle
     end
 
     def destroy_handle(handle : LibCUBLAS::Handle)


### PR DESCRIPTION
## Summary
- allocate cuBLAS handles on the stack instead of the heap

## Testing
- `crystal spec` *(fails: undefined constant CUDA::LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32F)*
- `crystal spec -D enable_cuda` *(fails: expected argument #11 to `SHAInet::CUDA.gemm_ex` to be LibCUBLAS::DataType)*

------
https://chatgpt.com/codex/tasks/task_e_6870d84e698883318df0039cf502f373