### PR TITLE
Fix FP16 copy size

### DIFF
--- a/spec/gpu_memory_fp16_copy_spec.cr
+++ b/spec/gpu_memory_fp16_copy_spec.cr
@@ -1,0 +1,27 @@
+require "./spec_helper"
+
+describe "GPUMemory FP16 copies" do
+  it "copies SimpleMatrix to GPU" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+    src = SHAInet::SimpleMatrix.from_a([[1.0, 2.0], [3.0, 4.0]], SHAInet::Precision::Fp16)
+    dest = SHAInet::CudaMatrix.new(2, 2, precision: SHAInet::Precision::Fp16)
+    SHAInet::GPUMemory.to_gpu!(src, dest)
+    dest.sync_from_device!
+    2.times do |i|
+      2.times do |j|
+        dest[i, j].should be_close(src[i, j], 1e-2)
+      end
+    end
+  end
+
+  it "copies FP16 array to GPU" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+    dest = SHAInet::CudaMatrix.new(1, 4, precision: SHAInet::Precision::Fp16)
+    arr = [1.0, 2.0, 3.0, 4.0]
+    SHAInet::GPUMemory.to_gpu!(arr, dest)
+    dest.sync_from_device!
+    4.times do |i|
+      dest[0, i].should be_close(arr[i], 1e-2)
+    end
+  end
+end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -56,7 +56,7 @@ module SHAInet
 
     getter rows, cols
 
-    private def element_size : Int32
+    def element_size : Int32
       case @precision
       when Precision::Int8
         1

--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -73,7 +73,7 @@ module SHAInet
       raise ArgumentError.new("size mismatch") unless src.rows == dest.rows && src.cols == dest.cols
 
       size = src.rows * src.cols
-      bytes = (size * 8).to_u64
+      bytes = (size * dest.element_size).to_u64
 
       dest_buf = dest.raw_data_buffer
       src_buf = Slice(UInt8).new(src.data.to_unsafe.as(UInt8*), bytes)
@@ -96,7 +96,7 @@ module SHAInet
       raise ArgumentError.new("size mismatch") unless matrix.rows == dest.rows && matrix.cols == dest.cols
 
       size = matrix.rows * matrix.cols
-      bytes = (size * 8).to_u64
+      bytes = (size * dest.element_size).to_u64
 
       dest_buf = dest.raw_data_buffer
       src_buf = Slice(UInt8).new(matrix.data.to_unsafe.as(UInt8*), bytes)
@@ -117,7 +117,7 @@ module SHAInet
       raise ArgumentError.new("size mismatch") unless dest.rows == 1 && dest.cols == array.size
 
       slice = Slice(Float64).new(array.size) { |i| array[i].to_f64 }
-      bytes = (array.size * 8).to_u64
+      bytes = (array.size * dest.element_size).to_u64
 
       dest_buf = dest.raw_data_buffer
       src_buf = Slice(UInt8).new(slice.to_unsafe.as(UInt8*), bytes)
@@ -145,7 +145,7 @@ module SHAInet
         array[i].as(Array)[j].as(GenNum).to_f64
       end
 
-      bytes = (rows * cols * 8).to_u64
+      bytes = (rows * cols * dest.element_size).to_u64
       dest_buf = dest.raw_data_buffer
       src_buf = Slice(UInt8).new(flat.to_unsafe.as(UInt8*), bytes)
       dest_buf.copy_from(src_buf)


### PR DESCRIPTION
## Summary
- account for matrix precision when copying CPU data to GPU
- expose `CudaMatrix#element_size`
- test GPUMemory half precision copies

## Testing
- `crystal spec --order=random spec/gpu_memory_fp16_copy_spec.cr`
- `crystal spec spec/cuda_copy_fp16_spec.cr`


------
https://chatgpt.com/codex/tasks/task_e_6870d823af5483318e66020a1a7648b9