### PR TITLE
Fix cuDNN scalar types

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -364,6 +364,10 @@ module SHAInet
       raise CudnnError.new("cuDNN not available")
     end
 
+    def typed_scalar(value : Float64, precision : Precision) : Bytes
+      Bytes.new(1)
+    end
+
     def softmax_cross_entropy_loss_and_gradient(*args)
       raise CudnnError.new("cuDNN not available")
     end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1024,9 +1024,9 @@ module SHAInet
             mat_desc = CUDNN.create_tensor_descriptor_2d(@rows, @cols, @precision)
             vec_desc = CUDNN.create_tensor_descriptor_2d(1, vec.cols, vec.precision)
 
-            alpha1 = 1.0
-            alpha2 = 1.0
-            beta = 0.0
+            alpha1_buf = CUDNN.typed_scalar(1.0, @precision)
+            alpha2_buf = CUDNN.typed_scalar(1.0, @precision)
+            beta_buf = CUDNN.typed_scalar(0.0, @precision)
 
             self.sync_to_device!("mul_row_vector") unless device_dirty?
             vec.sync_to_device!("mul_row_vector") unless vec.device_dirty?
@@ -1034,13 +1034,13 @@ module SHAInet
             CUDNN.check_status(LibCUDNN.cudnnOpTensor(
               CUDNN.handle,
               op_desc,
-              pointerof(alpha1).as(Pointer(Void)),
+              alpha1_buf.to_unsafe.as(Pointer(Void)),
               mat_desc,
               dptr.as(Pointer(Void)),
-              pointerof(alpha2).as(Pointer(Void)),
+              alpha2_buf.to_unsafe.as(Pointer(Void)),
               vec_desc,
               vptr.as(Pointer(Void)),
-              pointerof(beta).as(Pointer(Void)),
+              beta_buf.to_unsafe.as(Pointer(Void)),
               mat_desc,
               dptr.as(Pointer(Void))
             ))


### PR DESCRIPTION
## Summary
- add `typed_scalar` helper for cuDNN
- use typed constants in relu, softmax, add bias, element ops
- update CUDA stub to define `typed_scalar`

## Testing
- `crystal spec --order random` *(fails: undefined constant LibCUDNN)*
- `crystal spec -D enable_cuda` *(fails to compile CUDA bindings)*

------
https://chatgpt.com/codex/tasks/task_e_6870d80cb67c83318ca44b709edc2311