### PR TITLE
Add cuBLAS fallbacks for GEMM

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -116,6 +116,22 @@ module SHAInet
     def gemm_accumulate(*args)
     end
 
+    def sgemm(*args)
+    end
+
+    def sgemm_accumulate(*args)
+    end
+
+    def hgemm_available? : Bool
+      false
+    end
+
+    def hgemm(*args)
+    end
+
+    def hgemm_accumulate(*args)
+    end
+
     def geam(*args)
     end
 


### PR DESCRIPTION
## Summary
- add bindings for `cublasSgemm_v2` and `cublasHgemm`
- expose helpers `sgemm*` and `hgemm*`
- detect availability of `cublasHgemm`
- use these cuBLAS routines when `cublasGemmEx` is missing

## Testing
- `crystal spec -Denable_cuda --order=random` *(fails: expected argument #14 to 'SHAInet::CUDA.gemm_ex' to be SHAInet::CUDA::LibCUBLAS::ComputeType, not SHAInet::CUDA::ComputeType)*

------
https://chatgpt.com/codex/tasks/task_e_6870d853df9883318afb49f406a95fa2