### PR TITLE
Fix builds without CUDA

### DIFF
--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -243,23 +243,23 @@ module SHAInet
       case precision
       when Precision::Fp32
         buf = Bytes.new(sizeof(Float32))
-        buf.as(Pointer(Float32))[0] = value.to_f32
+        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
         buf
       when Precision::Fp16
         buf = Bytes.new(sizeof(Float16))
-        buf.as(Pointer(Float16))[0] = Float16.new(value)
+        buf.to_unsafe.as(Pointer(Float16))[0] = Float16.new(value)
         buf
       when Precision::Bf16
         buf = Bytes.new(sizeof(BFloat16))
-        buf.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
         buf
       when Precision::Int8
         buf = Bytes.new(sizeof(Int8))
-        buf.as(Pointer(Int8))[0] = value.round.to_i8
+        buf.to_unsafe.as(Pointer(Int8))[0] = value.round.to_i8
         buf
       else
         buf = Bytes.new(sizeof(Float64))
-        buf.as(Pointer(Float64))[0] = value
+        buf.to_unsafe.as(Pointer(Float64))[0] = value
         buf
       end
     end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1002,6 +1002,7 @@ module SHAInet
         return self
       elsif @precision.in?({Precision::Fp16, Precision::Bf16, Precision::Fp32}) &&
             vec.precision == @precision && CUDNN.available?
+        {% if flag?(:enable_cuda) %}
         stat = LibCUDNN.cudnnCreateOpTensorDescriptor(out op_desc)
         begin
           # # Broadcast multiply using cuDNN OpTensor
@@ -1054,6 +1055,7 @@ module SHAInet
             LibCUDNN.cudnnDestroyOpTensorDescriptor(opd)
           end
         end
+        {% end %}
       end
 
       # CPU fallback


### PR DESCRIPTION
## Summary
- ensure `typed_scalar` uses `to_unsafe` when writing typed buffers
- add full CUDA/CUDNN stubs so non-CUDA builds compile
- avoid compiling cuDNN-only code when CUDA is disabled

## Testing
- `crystal spec`
- `crystal build examples/babylm_transformer.cr --release`
- `crystal build examples/babylm_transformer.cr --release -Denable_cuda` *(fails to link: missing libcublas/libcudart)*

------
https://chatgpt.com/codex/tasks/task_e_6870de3dce848331823ccaeeca614d9b