### PR TITLE
Improve precision-aware CUDA fallbacks

### DIFF
--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -113,9 +113,9 @@ module SHAInet
                 @rows, @cols, prob, seed)
             {% else %}
               CUDA.dropout(
-                rptr.as(Pointer(Float64)),
-                dptr.as(Pointer(Float64)),
-                @rows, @cols, prob, seed)
+                rptr.as(Pointer(Void)),
+                dptr.as(Pointer(Void)),
+                @rows, @cols, prob, seed, @precision)
             {% end %}
           when Precision::Bf16
             {% if flag?(:cuda_bf16) %}
@@ -125,15 +125,15 @@ module SHAInet
                 @rows, @cols, prob, seed)
             {% else %}
               CUDA.dropout(
-                rptr.as(Pointer(Float64)),
-                dptr.as(Pointer(Float64)),
-                @rows, @cols, prob, seed)
+                rptr.as(Pointer(Void)),
+                dptr.as(Pointer(Void)),
+                @rows, @cols, prob, seed, @precision)
             {% end %}
           else
             CUDA.dropout(
-              rptr.as(Pointer(Float64)),
-              dptr.as(Pointer(Float64)),
-              @rows, @cols, prob, seed)
+              rptr.as(Pointer(Void)),
+              dptr.as(Pointer(Void)),
+              @rows, @cols, prob, seed, @precision)
           end
 
           # Mark result as having newer GPU data


### PR DESCRIPTION
## Summary
- respect matrix element size when using CUDA fallbacks
- add helper for precision element size
- handle fp16/fp32/bf16 buffers correctly for dropout, relu, gelu, and add_bias

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_68711f9f6830833193c9c3e8330d0019