### PR TITLE
Ensure CUBLAS handles cleaned up on exit

### DIFF
--- a/src/shainet.cr
+++ b/src/shainet.cr
@@ -68,3 +68,7 @@ module SHAInet
   iobackend = ::Log::IOBackend.new(io: STDOUT, dispatcher: ::Log::DispatchMode::Sync)
   ::Log.setup(lvl[log_level.downcase], backend: iobackend)
 end
+
+at_exit do
+  SHAInet::CUDA.cleanup_handles if SHAInet::CUDA.fully_available?
+end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1952,5 +1952,9 @@ module SHAInet
         end
       end
     end
+
+    def finalize
+      CUDA.cleanup_handles if CUDA.fully_available?
+    end
   end
 end


### PR DESCRIPTION
## Summary
- finalize Network class by cleaning CUDA handles
- free pooled CUDA handles on program shutdown

## Testing
- `crystal spec spec/cuda_detection_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68712131b7b4833183effdb3599b3121