### PR TITLE
Optimize label buffer usage

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -918,6 +918,7 @@ module SHAInet
 
       batch_size = stream ? mini_batch_size : mini_batch_size.clamp(1, raw_data.size)
       @accumulation_counter = 0
+      CUDNN.ensure_label_buffer(batch_size) if CUDNN.responds_to?(:ensure_label_buffer)
 
       epochs.times do |epoch|
         # Reset sync counters at start of each epoch
@@ -1004,6 +1005,7 @@ module SHAInet
 
       elapsed = Time.monotonic - start_time
       Log.info { "Training completed in #{elapsed.total_seconds.round(2)} seconds" }
+      CUDNN.free_label_buffer if CUDNN.responds_to?(:free_label_buffer)
     end
 
     private def process_batch(batch, cost_proc, training_type)

--- a/src/shainet/data_parallel_trainer.cr
+++ b/src/shainet/data_parallel_trainer.cr
@@ -31,6 +31,7 @@ module SHAInet
               log_each : Int32 = 1, error_threshold : Float64 = 0.0)
       cost_proc = cost_function.is_a?(Proc) ? cost_function.as(CostFunction) : @net.get_cost_proc(cost_function.to_s)
       batch_size = mini_batch_size.clamp(1, data.size)
+      CUDNN.ensure_label_buffer(batch_size) if CUDNN.responds_to?(:ensure_label_buffer)
 
       epochs.times do |epoch|
         total_error = 0.0
@@ -62,6 +63,8 @@ module SHAInet
         Log.info { "Epoch: #{epoch}, Error: #{avg_error}" } if epoch % log_each == 0
         break if avg_error < error_threshold
       end
+
+      CUDNN.free_label_buffer if CUDNN.responds_to?(:free_label_buffer)
     end
 
     private def clone_network(net : Network) : Network


### PR DESCRIPTION
## Summary
- allocate a persistent label index buffer in `CUDNN`
- use the buffer for `softmax_cross_entropy_label_loss_and_gradient`
- free the buffer after training

## Testing
- `crystal spec spec/softmax_cross_entropy_label_cuda_spec.cr spec/cross_entropy_cuda_precision_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68712122a0c083319ddf0f991f7c6a92