### PR TITLE
Fix CUDA compile path

### DIFF
--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -707,9 +707,9 @@ module SHAInet
         target.sync_to_device! unless target.device_dirty?
         grad_output.sync_to_device! unless grad_output.device_dirty?
         result = CUDA.mse_cost_gradient(
-          predicted.device_ptr.not_nil!,
-          target.device_ptr.not_nil!,
-          grad_output.device_ptr.not_nil!,
+          predicted.device_ptr.not_nil!.as(Pointer(Float64)),
+          target.device_ptr.not_nil!.as(Pointer(Float64)),
+          grad_output.device_ptr.not_nil!.as(Pointer(Float64)),
           loss_output,
           predicted.rows,
           predicted.cols


### PR DESCRIPTION
## Summary
- correct pointer casting for CUDA MSE loss gradient
- add label buffer helpers to cuda_stub so CPU builds compile

## Testing
- `crystal build examples/babylm_transformer.cr --release`
- `LIBRARY_PATH=/usr/local/cuda-12.5/targets/x86_64-linux/lib crystal build examples/babylm_transformer.cr --release -Denable_cuda`
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_687127497eb88331956f70543fbce4af