### PR TITLE
Fix set_row pointer arithmetic

### DIFF
--- a/spec/cuda_set_row_spec.cr
+++ b/spec/cuda_set_row_spec.cr
@@ -1,0 +1,45 @@
+require "./spec_helper"
+
+describe "CudaMatrix#set_row!" do
+  it "copies a row for FP32 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    src = SHAInet::CudaMatrix.from_a([
+      [1.0, 2.0, 3.0],
+      [4.0, 5.0, 6.0]
+    ], SHAInet::Precision::Fp32)
+
+    dst = SHAInet::CudaMatrix.from_a([
+      [0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0]
+    ], SHAInet::Precision::Fp32)
+
+    dst.set_row!(1, src, 0)
+    dst.sync_from_device!
+
+    3.times do |j|
+      dst[1, j].should be_close(src[0, j], 1e-6)
+    end
+  end
+
+  it "copies a row for FP16 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    src = SHAInet::CudaMatrix.from_a([
+      [1.0, 2.0, 3.0],
+      [4.0, 5.0, 6.0]
+    ], SHAInet::Precision::Fp16)
+
+    dst = SHAInet::CudaMatrix.from_a([
+      [0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0]
+    ], SHAInet::Precision::Fp16)
+
+    dst.set_row!(1, src, 0)
+    dst.sync_from_device!
+
+    3.times do |j|
+      dst[1, j].should be_close(src[0, j], 1e-2)
+    end
+  end
+end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -540,11 +540,10 @@ module SHAInet
       raise RuntimeError.new("GPU set_row! requires valid device pointers") unless dptr && sptr && !dptr.null? && !sptr.null?
 
       # Calculate pointers to the specific rows
-      dest_row_ptr = (dptr + (row_idx * @cols)).as(Pointer(Void))
-      src_row_ptr = (sptr + (source_row * other.cols)).as(Pointer(Void))
-
-      # Copy the row data taking element size into account
       elem_size = element_size
+      dest_row_ptr = (dptr + row_idx * @cols * elem_size).as(Pointer(Void))
+      src_row_ptr = (sptr + source_row * other.cols * elem_size).as(Pointer(Void))
+      # Copy the row data taking element size into account
       bytes = (@cols * elem_size).to_u64
 
       CUDA.copy_device_to_device(


### PR DESCRIPTION
## Summary
- account for element size when copying CUDA matrix rows
- regression spec for `CudaMatrix#set_row!` in non-FP64 precisions

## Testing
- `crystal spec spec/cuda_set_row_spec.cr -v`

------
https://chatgpt.com/codex/tasks/task_e_6871325fc894833189bebe00dae093ca