### PR TITLE
Add FP32 layer norm CUDA kernels

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -291,6 +291,10 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def row_mean_var_fp32(*args)
+      raise "CUDA kernels not available"
+    end
+
     def layer_norm(*args)
       raise "CUDA kernels not available"
     end
@@ -300,6 +304,10 @@ module SHAInet
     end
 
     def layer_norm_bf16(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def layer_norm_fp32(*args)
       raise "CUDA kernels not available"
     end
 

--- a/src/shainet/native/cuda_kernels.cu
+++ b/src/shainet/native/cuda_kernels.cu
@@ -391,6 +391,12 @@ void row_mean_var_bf16(const __nv_bfloat16 *in, float *mean, float *var,
   cudaDeviceSynchronize();
 }
 
+void row_mean_var_f32(const float *in, float *mean, float *var, int rows,
+                      int cols) {
+  row_mean_var_kernel_t<<<rows, 1>>>(in, mean, var, rows, cols);
+  cudaDeviceSynchronize();
+}
+
 __global__ void apply_layer_norm_kernel(double *out, const double *in,
                                         const double *mean, const double *var,
                                         int rows, int cols, double epsilon) {
@@ -423,6 +429,14 @@ void apply_layer_norm_fp16(__half *out, const __half *in, const float *mean,
 void apply_layer_norm_bf16(__nv_bfloat16 *out, const __nv_bfloat16 *in,
                            const float *mean, const float *var, int rows,
                            int cols, float epsilon) {
+  apply_layer_norm_kernel_t<<<rows, 1>>>(out, in, mean, var, rows, cols,
+                                         epsilon);
+  cudaDeviceSynchronize();
+}
+
+void apply_layer_norm_f32(float *out, const float *in, const float *mean,
+                          const float *var, int rows, int cols,
+                          float epsilon) {
   apply_layer_norm_kernel_t<<<rows, 1>>>(out, in, mean, var, rows, cols,
                                          epsilon);
   cudaDeviceSynchronize();

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -246,6 +246,18 @@ module SHAInet
             cuda_mean.device_ptr.not_nil!.as(Pointer(Float32)),
             cuda_var.device_ptr.not_nil!.as(Pointer(Float32)),
             rows, cols, @epsilon.to_f32)
+        when Precision::Fp32
+          CUDA.row_mean_var_fp32(
+            x.device_ptr.not_nil!.as(Pointer(Float32)),
+            cuda_mean.device_ptr.not_nil!.as(Pointer(Float32)),
+            cuda_var.device_ptr.not_nil!.as(Pointer(Float32)),
+            rows, cols)
+          CUDA.layer_norm_fp32(
+            cuda_norm.device_ptr.not_nil!.as(Pointer(Float32)),
+            x.device_ptr.not_nil!.as(Pointer(Float32)),
+            cuda_mean.device_ptr.not_nil!.as(Pointer(Float32)),
+            cuda_var.device_ptr.not_nil!.as(Pointer(Float32)),
+            rows, cols, @epsilon.to_f32)
         when Precision::Bf16
           CUDA.row_mean_var_bf16(
             x.device_ptr.not_nil!.as(Pointer(UInt16)),


### PR DESCRIPTION
## Summary
- implement FP32 versions of `row_mean_var` and `layer_norm` in CUDA kernels
- bind new CUDA kernel functions in `CUDA` module and stub
- call FP32 kernels from `LayerNorm` when input precision is FP32
- test GPU layer normalization parity for FP16 and FP32

## Testing
- `shards install`
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_6871388bfea88331a20dc2228e8b83e2