### PR TITLE
Fix GPU copy checks

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -318,11 +318,11 @@ module SHAInet
       LibCUDARuntime.cudaFree(ptr)
     end
 
-    def memcpy(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT, kind : MemcpyKind)
+    def memcpy(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT, kind : MemcpyKind) : Int32
       LibCUDARuntime.cudaMemcpy(dst, src, bytes, kind.value)
     end
 
-    def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT)
+    def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT) : Int32
       memcpy(dst, src, bytes, MemcpyKind::DeviceToDevice)
     end
 

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -129,11 +129,13 @@ module SHAInet
     def free(*args)
     end
 
-    def memcpy(*args)
+    def memcpy(*args) : Int32
+      0
     end
 
-    def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT)
+    def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT) : Int32
       # no-op when CUDA is disabled
+      0
     end
 
     def malloc_host(*args)


### PR DESCRIPTION
## Summary
- sync matrices in `safe_output_transform` before using GPU pointers
- return CUDA memcpy result and propagate via `copy_device_to_device`
- validate GPU memory copies in CUDA matrix helpers and network run
- stub out return values for CUDA disabled mode

## Testing
- `crystal spec --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_68713e85cdc483318f8a7eb8f10a620b