### PR TITLE
Fix gemm_ex compute type dispatch

### DIFF
--- a/spec/axpy_compute_type_spec.cr
+++ b/spec/axpy_compute_type_spec.cr
@@ -23,6 +23,13 @@ module SHAInet::CUDA
     @@recorded_types << compute_type
   end
 
+  def self.gemm_ex(handle : LibCUBLAS::Handle, a : Pointer(Void), b : Pointer(Void), c : Pointer(Void),
+                   m : Int32, n : Int32, k : Int32, lda : Int32, ldb : Int32, ldc : Int32,
+                   atype : DataType, btype : DataType, ctype : DataType,
+                   compute_type : ComputeType)
+    @@recorded_types << compute_type
+  end
+
   def self.recorded_types
     @@recorded_types
   end
@@ -65,6 +72,24 @@ describe "CUDA.axpy_ex compute type" do
     dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Bf16)
     ctype = SHAInet::CUDA.compute_type_for(SHAInet::Precision::Bf16)
     SHAInet::CUDA.axpy_ex(handle, 0.0_f32, Pointer(Void).null, dtype, Pointer(Void).null, dtype, 1, ctype)
+    SHAInet::CUDA.recorded_types.last.should eq(ctype)
+  end
+end
+
+describe "CUDA.gemm_ex compute type" do
+  it "passes compute_type_for value for fp16 and fp64" do
+    handle = Pointer(Void).null.as(SHAInet::CUDA::LibCUBLAS::Handle)
+
+    dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Fp16)
+    ctype = SHAInet::CUDA.compute_type_for(SHAInet::Precision::Fp16)
+    SHAInet::CUDA.gemm_ex(handle, Pointer(Void).null, Pointer(Void).null, Pointer(Void).null,
+      1, 1, 1, 1, 1, 1, dtype, dtype, dtype, ctype)
+    SHAInet::CUDA.recorded_types.last.should eq(ctype)
+
+    dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Fp64)
+    ctype = SHAInet::CUDA.compute_type_for(SHAInet::Precision::Fp64)
+    SHAInet::CUDA.gemm_ex(handle, Pointer(Void).null, Pointer(Void).null, Pointer(Void).null,
+      1, 1, 1, 1, 1, 1, dtype, dtype, dtype, ctype)
     SHAInet::CUDA.recorded_types.last.should eq(ctype)
   end
 end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -447,15 +447,44 @@ module SHAInet
                 m : Int32, n : Int32, k : Int32, lda : Int32, ldb : Int32, ldc : Int32,
                 atype : LibCUBLAS::DataType, btype : LibCUBLAS::DataType, ctype : LibCUBLAS::DataType,
                 compute_type : LibCUBLAS::ComputeType)
-      alpha = 1.0_f32
-      beta = 0.0_f32
+      alpha_ptr = Pointer(Void).null
+      beta_ptr = Pointer(Void).null
+
+      case compute_type
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16F
+        alpha = SHAInet::Float16.new(1.0_f32)
+        beta = SHAInet::Float16.new(0.0_f32)
+        alpha_ptr = pointerof(alpha).as(Void*)
+        beta_ptr = pointerof(beta).as(Void*)
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
+        alpha = SHAInet::BFloat16.new(1.0_f32)
+        beta = SHAInet::BFloat16.new(0.0_f32)
+        alpha_ptr = pointerof(alpha).as(Void*)
+        beta_ptr = pointerof(beta).as(Void*)
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
+        alpha = 1.0_f64
+        beta = 0.0_f64
+        alpha_ptr = pointerof(alpha).as(Void*)
+        beta_ptr = pointerof(beta).as(Void*)
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I
+        alpha = 1_i32
+        beta = 0_i32
+        alpha_ptr = pointerof(alpha).as(Void*)
+        beta_ptr = pointerof(beta).as(Void*)
+      else
+        alpha = 1.0_f32
+        beta = 0.0_f32
+        alpha_ptr = pointerof(alpha).as(Void*)
+        beta_ptr = pointerof(beta).as(Void*)
+      end
+
       LibCUBLAS.cublasGemmEx(handle,
         Operation::N.value, Operation::N.value,
         m, n, k,
-        pointerof(alpha).as(Void*),
+        alpha_ptr,
         a, atype.value, lda,
         b, btype.value, ldb,
-        pointerof(beta).as(Void*),
+        beta_ptr,
         c, ctype.value, ldc,
         compute_type.value, 0)
     end


### PR DESCRIPTION
## Summary
- dispatch `gemm_ex` scalars based on compute type
- test GEMM compute type dispatch for FP16 and FP64

## Testing
- `crystal spec spec/axpy_compute_type_spec.cr`
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_687168f8964c833188ff9c13a08d64d9