### PR TITLE
Adjust alpha handling for axpy_ex

### DIFF
--- a/spec/axpy_compute_type_spec.cr
+++ b/spec/axpy_compute_type_spec.cr
@@ -18,7 +18,7 @@ module SHAInet::CUDA
 
   @@recorded_types = [] of ComputeType
 
-  def self.axpy_ex(handle : LibCUBLAS::Handle, alpha : Float32, x : Pointer(Void), x_type : DataType,
+  def self.axpy_ex(handle : LibCUBLAS::Handle, alpha : Void*, x : Pointer(Void), x_type : DataType,
                    y : Pointer(Void), y_type : DataType, n : Int32, compute_type : ComputeType)
     @@recorded_types << compute_type
   end
@@ -59,12 +59,12 @@ describe "CUDA.axpy_ex compute type" do
     handle = Pointer(Void).null.as(SHAInet::CUDA::LibCUBLAS::Handle)
     dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Fp16)
     ctype = SHAInet::CUDA.compute_type_for(SHAInet::Precision::Fp16)
-    SHAInet::CUDA.axpy_ex(handle, 0.0_f32, Pointer(Void).null, dtype, Pointer(Void).null, dtype, 1, ctype)
+    SHAInet::CUDA.axpy_ex(handle, Pointer(Void).null, Pointer(Void).null, dtype, Pointer(Void).null, dtype, 1, ctype)
     SHAInet::CUDA.recorded_types.last.should eq(ctype)
 
     dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Bf16)
     ctype = SHAInet::CUDA.compute_type_for(SHAInet::Precision::Bf16)
-    SHAInet::CUDA.axpy_ex(handle, 0.0_f32, Pointer(Void).null, dtype, Pointer(Void).null, dtype, 1, ctype)
+    SHAInet::CUDA.axpy_ex(handle, Pointer(Void).null, Pointer(Void).null, dtype, Pointer(Void).null, dtype, 1, ctype)
     SHAInet::CUDA.recorded_types.last.should eq(ctype)
   end
 end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -145,6 +145,37 @@ module SHAInet
       end
     end
 
+    # Return a small typed buffer containing `value` for the given compute type.
+    # The returned slice must be kept alive while passed to cuBLAS.
+    def scalar_for_compute_type(value : Float64, compute_type : LibCUBLAS::ComputeType) : Bytes
+      case compute_type
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
+        buf = Bytes.new(sizeof(Float64))
+        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32F
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16F
+        buf = Bytes.new(sizeof(Float16))
+        buf.to_unsafe.as(Pointer(Float16))[0] = Float16.new(value)
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
+        buf = Bytes.new(sizeof(BFloat16))
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I
+        buf = Bytes.new(sizeof(Int32))
+        buf.to_unsafe.as(Pointer(Int32))[0] = value.round.to_i32
+        buf
+      else
+        buf = Bytes.new(sizeof(Float64))
+        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf
+      end
+    end
+
     @@gemm_ex_available : Bool? = nil
     @@axpy_ex_available : Bool? = nil
 
@@ -587,10 +618,10 @@ module SHAInet
       LibCUBLAS.cublasSaxpy_v2(handle, n, pointerof(alpha), x, 1, y, 1)
     end
 
-    def axpy_ex(handle : LibCUBLAS::Handle, alpha : Float32, x : Pointer(Void), x_type : LibCUBLAS::DataType,
+    def axpy_ex(handle : LibCUBLAS::Handle, alpha : Void*, x : Pointer(Void), x_type : LibCUBLAS::DataType,
                 y : Pointer(Void), y_type : LibCUBLAS::DataType, n : Int32, compute_type : LibCUBLAS::ComputeType)
       LibCUBLAS.cublasAxpyEx(handle, n,
-        pointerof(alpha).as(Void*),
+        alpha,
         x, x_type.value, 1,
         y, y_type.value, 1,
         compute_type.value)

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -534,6 +534,35 @@ module SHAInet
       end
     end
 
+    def scalar_for_compute_type(value : Float64, compute_type : LibCUBLAS::ComputeType) : Bytes
+      case compute_type
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
+        buf = Bytes.new(sizeof(Float64))
+        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32F
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16F
+        buf = Bytes.new(sizeof(Float16))
+        buf.to_unsafe.as(Pointer(Float16))[0] = Float16.new(value)
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
+        buf = Bytes.new(sizeof(BFloat16))
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf
+      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I
+        buf = Bytes.new(sizeof(Int32))
+        buf.to_unsafe.as(Pointer(Int32))[0] = value.round.to_i32
+        buf
+      else
+        buf = Bytes.new(sizeof(Float64))
+        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf
+      end
+    end
+
     def softmax_cross_entropy_loss_and_gradient(*args)
       raise CudnnError.new("cuDNN not available")
     end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1700,7 +1700,8 @@ module SHAInet
           elsif CUDA.axpy_ex_available?
             dtype = CUDA.data_type_for(Precision::Fp16)
             ctype = CUDA.compute_type_for(Precision::Fp16)
-            CUDA.axpy_ex(handle, -learning_rate.to_f32, grad_ptr.as(Void*), dtype, weight_ptr.as(Void*), dtype, total_elements, ctype)
+            scalar = CUDA.scalar_for_compute_type(-learning_rate, ctype)
+            CUDA.axpy_ex(handle, scalar.to_unsafe, grad_ptr.as(Void*), dtype, weight_ptr.as(Void*), dtype, total_elements, ctype)
           else
             raise "axpyEx unavailable"
           end
@@ -1710,7 +1711,8 @@ module SHAInet
           elsif CUDA.axpy_ex_available?
             dtype = CUDA.data_type_for(Precision::Bf16)
             ctype = CUDA.compute_type_for(Precision::Bf16)
-            CUDA.axpy_ex(handle, -learning_rate.to_f32, grad_ptr.as(Void*), dtype, weight_ptr.as(Void*), dtype, total_elements, ctype)
+            scalar = CUDA.scalar_for_compute_type(-learning_rate, ctype)
+            CUDA.axpy_ex(handle, scalar.to_unsafe, grad_ptr.as(Void*), dtype, weight_ptr.as(Void*), dtype, total_elements, ctype)
           else
             raise "axpyEx unavailable"
           end


### PR DESCRIPTION
## Summary
- update `axpy_ex` to accept a `Void*` alpha pointer
- provide `scalar_for_compute_type` helper to create typed scalars
- use typed scalar in `CudaMatrix.weight_update!`
- adjust stub and spec for new signature

## Testing
- `crystal tool format src/shainet/cuda.cr src/shainet/cuda_stub.cr src/shainet/math/cuda_matrix.cr spec/axpy_compute_type_spec.cr`
- `shards install`
- `crystal spec spec/axpy_compute_type_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_687168fca25c833183bc21e9c78d8cb3