### PR TITLE
Fix CUDA copy_device_to_device error handling

### DIFF
--- a/spec/cuda_copy_fp16_spec.cr
+++ b/spec/cuda_copy_fp16_spec.cr
@@ -23,4 +23,21 @@ describe "CUDA copy_device_to_device FP16" do
       dst[0, i].should eq(src[0, i])
     end
   end
+
+  it "raises when using an invalid pointer" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    src = SHAInet::CudaMatrix.new(1, 4, precision: SHAInet::Precision::Fp16)
+    dst = SHAInet::CudaMatrix.new(1, 4, precision: SHAInet::Precision::Fp16)
+
+    src.sync_to_device!
+    dst.sync_to_device!
+
+    bytes = (4 * 2).to_u64
+    invalid_ptr = Pointer(Void).null
+
+    expect_raises(RuntimeError, /cudaMemcpy DeviceToDevice failed/) do
+      SHAInet::CUDA.copy_device_to_device(dst.device_ptr.not_nil!, invalid_ptr, bytes)
+    end
+  end
 end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -354,7 +354,11 @@ module SHAInet
     end
 
     def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT) : Int32
-      memcpy(dst, src, bytes, MemcpyKind::DeviceToDevice)
+      result = memcpy(dst, src, bytes, MemcpyKind::DeviceToDevice)
+      unless result.zero?
+        raise RuntimeError.new("cudaMemcpy DeviceToDevice failed: #{result}")
+      end
+      result
     end
 
     def malloc_host(ptr : Pointer(Pointer(Void)), size : LibC::SizeT)


### PR DESCRIPTION
## Summary
- check the return value from `cudaMemcpy` when copying device memory
- raise `RuntimeError` if the call fails
- test that invalid pointers raise an error

## Testing
- `crystal spec spec/cuda_copy_fp16_spec.cr`
- `crystal spec` *(fails: undefined method 'scalar_for_compute_type')*

------
https://chatgpt.com/codex/tasks/task_e_68716d467d00833195dadc36b515fb07