### PR TITLE
Add GPU zero kernels for fp16/bf16/fp32

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -369,6 +369,18 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def zero_matrix_fp16(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def zero_matrix_bf16(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def zero_matrix_fp32(*args)
+      raise "CUDA kernels not available"
+    end
+
     def fill_matrix(*args)
       raise "CUDA kernels not available"
     end

--- a/src/shainet/native/cuda_kernels.cu
+++ b/src/shainet/native/cuda_kernels.cu
@@ -847,6 +847,16 @@ __global__ void zero_matrix_kernel(double *matrix, int size) {
   matrix[idx] = 0.0;
 }
 
+// Generic kernel for other precisions
+template <typename T>
+__global__ void zero_matrix_kernel_t(T *matrix, int size) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= size)
+    return;
+
+  matrix[idx] = Convert<T>::from_float(0.0f);
+}
+
 void zero_matrix(double *matrix, int size) {
   int threads_per_block = 256;
   int blocks = (size + threads_per_block - 1) / threads_per_block;
@@ -855,6 +865,36 @@ void zero_matrix(double *matrix, int size) {
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
     printf("CUDA Error in zero_matrix: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void zero_matrix_fp16(__half *matrix, int size) {
+  int threads_per_block = 256;
+  int blocks = (size + threads_per_block - 1) / threads_per_block;
+  zero_matrix_kernel_t<<<blocks, threads_per_block>>>(matrix, size);
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA Error in zero_matrix_fp16: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void zero_matrix_bf16(__nv_bfloat16 *matrix, int size) {
+  int threads_per_block = 256;
+  int blocks = (size + threads_per_block - 1) / threads_per_block;
+  zero_matrix_kernel_t<<<blocks, threads_per_block>>>(matrix, size);
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA Error in zero_matrix_bf16: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void zero_matrix_fp32(float *matrix, int size) {
+  int threads_per_block = 256;
+  int blocks = (size + threads_per_block - 1) / threads_per_block;
+  zero_matrix_kernel_t<<<blocks, threads_per_block>>>(matrix, size);
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA Error in zero_matrix_fp32: %s\n", cudaGetErrorString(err));
   }
 }
 


### PR DESCRIPTION
## Summary
- add CUDA kernels for zeroing fp16, bf16 and fp32 matrices
- expose `CUDA.zero_matrix_fp16`, `zero_matrix_bf16` and `zero_matrix_fp32`
- use these new kernels in `CudaMatrix#zero!`
- provide stub methods for non-CUDA builds

## Testing
- `crystal spec --order=random --error-trace` *(fails: undefined method 'scalar_for_compute_type')*

------
https://chatgpt.com/codex/tasks/task_e_68716d6252d0833187b00fb0983104fa