### PR TITLE
Handle zero-length GPU matrices in safe_output_transform

### DIFF
--- a/spec/safe_output_transform_spec.cr
+++ b/spec/safe_output_transform_spec.cr
@@ -37,4 +37,34 @@ describe "safe_output_transform" do
     output.cols.should eq 1
     output[0, 0].should be_close(input[1, 0]*1.0 + input[1, 1]*2.0, 1e-6)
   end
+
+  it "raises on zero rows" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    net = SHAInet::Network.new
+    net.precision = SHAInet::Precision::Fp32
+    net.hidden_layers << SHAInet::TransformerBlock.new(2, 1, 2)
+
+    input = SHAInet::CudaMatrix.new(0, 2, precision: SHAInet::Precision::Fp32)
+    weights = SHAInet::CudaMatrix.new(2, 1, precision: SHAInet::Precision::Fp32)
+
+    expect_raises(RuntimeError) do
+      net.call_safe_output_transform(input, weights)
+    end
+  end
+
+  it "raises on zero columns" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    net = SHAInet::Network.new
+    net.precision = SHAInet::Precision::Fp32
+    net.hidden_layers << SHAInet::TransformerBlock.new(2, 1, 2)
+
+    input = SHAInet::CudaMatrix.new(2, 0, precision: SHAInet::Precision::Fp32)
+    weights = SHAInet::CudaMatrix.new(0, 1, precision: SHAInet::Precision::Fp32)
+
+    expect_raises(RuntimeError) do
+      net.call_safe_output_transform(input, weights)
+    end
+  end
 end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1612,6 +1612,11 @@ module SHAInet
         if matrix.device_id != weights.device_id
           raise RuntimeError.new("CUDA device mismatch: #{matrix.device_id} vs #{weights.device_id}")
         end
+
+        if matrix.rows == 0 || matrix.cols == 0
+          raise RuntimeError.new("safe_output_transform: matrix has zero rows or columns")
+        end
+
         matrix.sync_to_device!("safe_output_transform")
         weights.sync_to_device!("safe_output_transform")
         # For transformer architectures, use only the last token's representation


### PR DESCRIPTION
## Summary
- prevent CUDA calls on zero-length inputs in `safe_output_transform`
- test that zero-row/zero-column inputs raise a RuntimeError

## Testing
- `crystal spec --error-trace --order=random` *(fails: expected argument #2 to 'SHAInet::CUDA.scalar_for_compute_type' to be SHAInet::CUDA::LibCUBLAS::ComputeType, not SHAInet::CUDA::ComputeType)*

------
https://chatgpt.com/codex/tasks/task_e_68727def73d4833191a4e90032a96e4d