### PR TITLE
Add CUDA element-wise multiply kernels

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1777,9 +1777,32 @@ module SHAInet
         end
       end
 
-      # CPU fallback
       raise ArgumentError.new("size mismatch") unless @rows == other.rows && @cols == other.cols
       ensure_same_device(other)
+
+      if CUDA.fully_available? && (sptr = self.device_ptr) && (optr = other.device_ptr) && !sptr.null? && !optr.null?
+        begin
+          self.sync_to_device!("element_mul_kernel") unless device_dirty?
+          other.sync_to_device!("element_mul_kernel") unless other.device_dirty?
+          size = @rows * @cols
+          case @precision
+          when Precision::Fp16
+            CUDA.element_mul_fp16(sptr.as(Pointer(UInt16)), optr.as(Pointer(UInt16)), alpha, beta, size)
+          when Precision::Bf16
+            CUDA.element_mul_bf16(sptr.as(Pointer(UInt16)), optr.as(Pointer(UInt16)), alpha, beta, size)
+          when Precision::Fp32
+            CUDA.element_mul_fp32(sptr.as(Pointer(Float32)), optr.as(Pointer(Float32)), alpha, beta, size)
+          else
+            CUDA.element_mul(sptr.as(Pointer(Float64)), optr.as(Pointer(Float64)), alpha, beta, size)
+          end
+          mark_device_dirty!
+          return self
+        rescue e : Exception
+          Log.error { "CUDA element_mul kernel failed: #{e}, falling back to CPU" }
+        end
+      end
+
+      # CPU fallback
       self.sync_from_device!("cudnn_element_mul_fallback") if device_dirty?
       other.sync_from_device!("cudnn_element_mul_fallback") if other.device_dirty?
 
@@ -1791,7 +1814,7 @@ module SHAInet
           self.unsafe_set(i, j, result_val)
         end
       end
-      self.sync_to_device!("cudnn_element_mul_result")
+      self.sync_to_device!("cudnn_element_mul_result") if CUDA.available?
       mark_device_dirty!
       self
     end


### PR DESCRIPTION
## Summary
- implement `element_mul_kernel_t` for half, bfloat16, float and double
- expose `element_mul_fp16`, `element_mul_bf16`, `element_mul_fp32` and `element_mul` through `CUDA`
- call the new kernels from `CudaMatrix#element_mul!` when cuDNN isn't used

## Testing
- `crystal spec spec/cuda_detection_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68727a321cdc83319d61eeac7ddce484