### PR TITLE
Add CUDA element-wise multiply kernel

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -715,6 +715,10 @@ module SHAInet
     @@fill_matrix_proc : Proc(Pointer(Float64), Float64, Int32, Void)? = nil
     @@scale_fp16_proc : Proc(Pointer(UInt16), Float32, Int32, Void)? = nil
     @@scale_bf16_proc : Proc(Pointer(UInt16), Float32, Int32, Void)? = nil
+    @@element_mul_proc : Proc(Pointer(Float64), Pointer(Float64), Pointer(Float64), Float64, Float64, Int32, Void)? = nil
+    @@element_mul_fp16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Float64, Float64, Int32, Void)? = nil
+    @@element_mul_bf16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Float64, Float64, Int32, Void)? = nil
+    @@element_mul_fp32_proc : Proc(Pointer(Float32), Pointer(Float32), Pointer(Float32), Float64, Float64, Int32, Void)? = nil
     @@element_div_proc : Proc(Pointer(Float64), Pointer(Float64), Pointer(Float64), Int32, Void)? = nil
     @@element_div_fp16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Int32, Void)? = nil
     @@element_div_bf16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Int32, Void)? = nil
@@ -1706,6 +1710,78 @@ module SHAInet
       end
       raise "CUDA kernels not available" unless fn
       fn.call(dst, a, b, size)
+    end
+
+    def element_mul(dst : Pointer(Float64), a : Pointer(Float64), b : Pointer(Float64), alpha : Float64, beta : Float64, size : Int32)
+      return if dst.null? || a.null? || b.null? || size <= 0
+      unless fn = @@element_mul_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "element_mul")
+          unless sym.null?
+            @@element_mul_proc = Proc(Pointer(Float64), Pointer(Float64), Pointer(Float64), Float64, Float64, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@element_mul_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, a, b, alpha, beta, size)
+    end
+
+    def element_mul_fp16(dst : Pointer(UInt16), a : Pointer(UInt16), b : Pointer(UInt16), alpha : Float64, beta : Float64, size : Int32)
+      return if dst.null? || a.null? || b.null? || size <= 0
+      unless fn = @@element_mul_fp16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "element_mul_fp16")
+          unless sym.null?
+            @@element_mul_fp16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Float64, Float64, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@element_mul_fp16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, a, b, alpha, beta, size)
+    end
+
+    def element_mul_bf16(dst : Pointer(UInt16), a : Pointer(UInt16), b : Pointer(UInt16), alpha : Float64, beta : Float64, size : Int32)
+      return if dst.null? || a.null? || b.null? || size <= 0
+      unless fn = @@element_mul_bf16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "element_mul_bf16")
+          unless sym.null?
+            @@element_mul_bf16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Pointer(UInt16), Float64, Float64, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@element_mul_bf16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, a, b, alpha, beta, size)
+    end
+
+    def element_mul_fp32(dst : Pointer(Float32), a : Pointer(Float32), b : Pointer(Float32), alpha : Float64, beta : Float64, size : Int32)
+      return if dst.null? || a.null? || b.null? || size <= 0
+      unless fn = @@element_mul_fp32_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "element_mul_f32")
+          unless sym.null?
+            @@element_mul_fp32_proc = Proc(Pointer(Float32), Pointer(Float32), Pointer(Float32), Float64, Float64, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@element_mul_fp32_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, a, b, alpha, beta, size)
     end
 
     # In-place element-wise ReLU on GPU memory. This fallback implementation


### PR DESCRIPTION
## Summary
- implement `element_mul_kernel_t` with support for FP64/FP32/FP16/BF16
- expose new CUDA wrappers for element-wise multiplication
- use CUDA kernels in `CudaMatrix#element_mul!` when cuDNN is unavailable

## Testing
- `crystal spec --error-trace` *(fails: expecting token 'CONST', not '__orig_gemm_ex')*

------
https://chatgpt.com/codex/tasks/task_e_6872afe317648331907e957c58ea22a9