### PR TITLE
Fix GPU input cast

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1402,12 +1402,17 @@ module SHAInet
           rows = arr.size
           cols = arr[0].as(Array).size
           mat = CudaMatrix.new(rows, cols, precision: @precision)
-          GPUMemory.to_gpu!(arr.as(Array(Array(GenNum))), mat)
+          arr_typed = Array(Array(GenNum)).new(rows) do |i|
+            row = arr[i].as(Array)
+            Array(GenNum).new(cols) { |j| row[j].as(GenNum) }
+          end
+          GPUMemory.to_gpu!(arr_typed, mat)
           mat
         else
           cols = arr.size
           mat = CudaMatrix.new(1, cols, precision: @precision)
-          GPUMemory.to_gpu!(arr.as(Array(GenNum)), mat)
+          arr_typed = Array(GenNum).new(cols) { |i| arr[i].as(GenNum) }
+          GPUMemory.to_gpu!(arr_typed, mat)
           mat
         end
       else


### PR DESCRIPTION
## Summary
- fix union handling when converting arrays to CudaMatrix
- handle values as `GenNum` before uploading to GPU

## Testing
- `crystal build examples/babylm_transformer.cr --release`
- `crystal build examples/babylm_transformer.cr --release -Denable_cuda` *(fails at link step: missing cublas/cudart)*

------
https://chatgpt.com/codex/tasks/task_e_6872b0b9d9908331a4cc3d009e151cb8