### PR TITLE
Improve device copy error logs

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1543,7 +1543,10 @@ module SHAInet
                              copy_bytes.to_u64
                            )
                            if copy_res != 0
-                             Log.error { "safe_output_transform: device copy failed with code #{copy_res}" }
+                             Log.error {
+                               "safe_output_transform: device copy failed with code #{copy_res} " \
+                               "(dst #{result.rows}x#{result.cols}, src #{matrix.rows}x#{matrix.cols})"
+                             }
                              raise RuntimeError.new("GPU memory copy failed in safe_output_transform for transformer output")
                            end
                            result.mark_device_dirty!

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -579,7 +579,10 @@ module SHAInet
         src_row_ptr,
         bytes)
       if copy_res != 0
-        Log.error { "set_row!: device copy failed with code #{copy_res}" }
+        Log.error {
+          "set_row!: device copy failed with code #{copy_res} " \
+          "(dst #{rows}x#{cols}, src #{other.rows}x#{other.cols})"
+        }
         raise RuntimeError.new("GPU memory copy failed in set_row! from other to self")
       end
 


### PR DESCRIPTION
## Summary
- include matrix dimensions in safe_output_transform device copy errors
- include matrix dimensions in CudaMatrix#set_row! device copy errors

## Testing
- `crystal spec spec/cuda_set_row_spec.cr spec/safe_output_transform_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68735cde4cf08331a31afb903cfb4a20