### PR TITLE
Fix CUDA pointer casts and isolate axpy compute type spec

### DIFF
--- a/spec/axpy_compute_type_spec.cr
+++ b/spec/axpy_compute_type_spec.cr
@@ -2,19 +2,8 @@ require "./spec_helper"
 
 # Monkey patch CUDA.axpy_ex to record the compute type used
 module SHAInet::CUDA
-  enum DataType
-    CUDA_R_32F  =  0
-    CUDA_R_64F  =  1
-    CUDA_R_16F  =  2
-    CUDA_R_16BF = 14
-  end
-
-  enum ComputeType
-    CUBLAS_COMPUTE_16F  =  64
-    CUBLAS_COMPUTE_32F  =  68
-    CUBLAS_COMPUTE_64F  =  70
-    CUBLAS_COMPUTE_16BF = 119
-  end
+  alias DataType = LibCUBLAS::DataType
+  alias ComputeType = LibCUBLAS::ComputeType
 
   @@recorded_types = [] of ComputeType
 
@@ -36,28 +25,6 @@ module SHAInet::CUDA
 
   def self.axpy_ex_available?
     true
-  end
-
-  def self.data_type_for(p : Precision) : DataType
-    case p
-    when Precision::Fp16
-      DataType::CUDA_R_16F
-    when Precision::Bf16
-      DataType::CUDA_R_16BF
-    else
-      DataType::CUDA_R_32F
-    end
-  end
-
-  def self.compute_type_for(p : Precision) : ComputeType
-    case p
-    when Precision::Fp16
-      ComputeType::CUBLAS_COMPUTE_16F
-    when Precision::Bf16
-      ComputeType::CUBLAS_COMPUTE_16BF
-    else
-      ComputeType::CUBLAS_COMPUTE_32F
-    end
   end
 end
 

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -650,9 +650,9 @@ module SHAInet
       grad_output.sync_to_device!("xent_grad") unless grad_output.device_dirty?
 
       result = CUDA.cross_entropy_loss_gradient(
-        predicted.device_ptr.not_nil!,
-        target.device_ptr.not_nil!,
-        grad_output.device_ptr.not_nil!,
+        predicted.device_ptr.not_nil!.as(Pointer(Float64)),
+        target.device_ptr.not_nil!.as(Pointer(Float64)),
+        grad_output.device_ptr.not_nil!.as(Pointer(Float64)),
         loss_output,
         predicted.rows,
         predicted.cols
@@ -687,7 +687,10 @@ module SHAInet
       # Use CUDA kernel for cross-entropy computation
       total_elements = predicted.rows * predicted.cols
       result = CUDA.cross_entropy_loss_gradient(
-        pred_ptr, target_ptr, grad_ptr, loss_output,
+        pred_ptr.as(Pointer(Float64)),
+        target_ptr.as(Pointer(Float64)),
+        grad_ptr.as(Pointer(Float64)),
+        loss_output,
         predicted.rows, predicted.cols
       )
 


### PR DESCRIPTION
## Summary
- fix wrong pointer types when calling CUDA cross-entropy routines
- prevent axpy compute type spec from overriding main CUDA helpers

## Testing
- `crystal spec --verbose -Denable_cuda --error-trace` *(fails: 169 examples, 0 failures, 19 errors, 50 pending)*

------
https://chatgpt.com/codex/tasks/task_e_6873626df0f883319e27c2b51faf3cd8