### PR TITLE
Fix FP16 GPU copy helpers

### DIFF
--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -68,24 +68,20 @@ module SHAInet
       to_gpu!(matrix, target)
     end
 
-    # Copy values from +src+ into existing GPU matrix +dest+
-    def to_gpu!(src : SimpleMatrix, dest : CudaMatrix)
-      raise ArgumentError.new("size mismatch") unless src.rows == dest.rows && src.cols == dest.cols
+      # Copy values from +src+ into existing GPU matrix +dest+
+      # Handles precision conversion on the CPU before syncing to the GPU.
+      def to_gpu!(src : SimpleMatrix, dest : CudaMatrix)
+        raise ArgumentError.new("size mismatch") unless src.rows == dest.rows && src.cols == dest.cols
 
-      size = src.rows * src.cols
-      bytes = (size * dest.element_size).to_u64
+        src.rows.times do |i|
+          src.cols.times do |j|
+            dest[i, j] = src[i, j]
+          end
+        end
 
-      dest_buf = dest.raw_data_buffer
-      src_buf = Slice(UInt8).new(src.data.to_unsafe.as(UInt8*), bytes)
-      dest_buf.copy_from(src_buf)
-
-      if (dptr = dest.device_ptr) && !dptr.null?
-        result = CUDA.memcpy(dptr.as(Pointer(Void)), src_buf.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
-        Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
+        dest.sync_to_device!("to_gpu!")
+        dest
       end
-      dest.sync_to_device!("to_gpu!")
-      dest
-    end
 
     # Copy data from +matrix+ into an existing CudaMatrix +dest+
     # and sync it to the device. The destination must have the
@@ -94,17 +90,12 @@ module SHAInet
       return dest unless CUDA.fully_available?
       raise ArgumentError.new("size mismatch") unless matrix.rows == dest.rows && matrix.cols == dest.cols
 
-      size = matrix.rows * matrix.cols
-      bytes = (size * dest.element_size).to_u64
-
-      dest_buf = dest.raw_data_buffer
-      src_buf = Slice(UInt8).new(matrix.data.to_unsafe.as(UInt8*), bytes)
-      dest_buf.copy_from(src_buf)
-
-      if (dptr = dest.device_ptr) && !dptr.null?
-        result = CUDA.memcpy(dptr.as(Pointer(Void)), src_buf.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
-        Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
+      matrix.rows.times do |i|
+        matrix.cols.times do |j|
+          dest[i, j] = matrix[i, j]
+        end
       end
+
       dest.sync_to_device!("to_gpu!")
       dest
     end
@@ -114,17 +105,10 @@ module SHAInet
       return dest unless CUDA.fully_available?
       raise ArgumentError.new("size mismatch") unless dest.rows == 1 && dest.cols == array.size
 
-      slice = Slice(Float64).new(array.size) { |i| array[i].to_f64 }
-      bytes = (array.size * dest.element_size).to_u64
-
-      dest_buf = dest.raw_data_buffer
-      src_buf = Slice(UInt8).new(slice.to_unsafe.as(UInt8*), bytes)
-      dest_buf.copy_from(src_buf)
-
-      if (dptr = dest.device_ptr) && !dptr.null?
-        result = CUDA.memcpy(dptr.as(Pointer(Void)), src_buf.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
-        Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
+      array.each_with_index do |val, idx|
+        dest[0, idx] = val.to_f64
       end
+
       dest.sync_to_device!("to_gpu!")
       dest
     end
@@ -136,21 +120,12 @@ module SHAInet
       cols = array[0].as(Array).size
       raise ArgumentError.new("size mismatch") unless dest.rows == rows && dest.cols == cols
 
-      flat = Array(Float64).new(rows * cols) do |idx|
-        i = idx // cols
-        j = idx % cols
-        array[i].as(Array)[j].as(GenNum).to_f64
+      rows.times do |i|
+        cols.times do |j|
+          dest[i, j] = array[i][j].to_f64
+        end
       end
 
-      bytes = (rows * cols * dest.element_size).to_u64
-      dest_buf = dest.raw_data_buffer
-      src_buf = Slice(UInt8).new(flat.to_unsafe.as(UInt8*), bytes)
-      dest_buf.copy_from(src_buf)
-
-      if (dptr = dest.device_ptr) && !dptr.null?
-        result = CUDA.memcpy(dptr.as(Pointer(Void)), src_buf.to_unsafe.as(Pointer(Void)), bytes, CUDA::MemcpyKind::HostToDevice)
-        Log.error { "GPUMemory.to_gpu!: GPU memcpy failed with result #{result}" } if result != 0
-      end
       dest.sync_to_device!("to_gpu!")
       dest
     end


### PR DESCRIPTION
## Summary
- handle precision conversion when copying FP16 data to GPU
- adjust array copy helpers for FP16

## Testing
- `LOG_LEVEL=INFO crystal spec spec/gpu_memory_fp16_copy_spec.cr --verbose -Denable_cuda --error-trace` *(fails: CudaMatrix requires CUDA to be available)*

------
https://chatgpt.com/codex/tasks/task_e_6873812adb88833189db53d628b82a83