### PR TITLE
Add CPU fallback for fp32 gemm!

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1706,7 +1706,21 @@ module SHAInet
             alpha.to_f32, beta.to_f32)
           if status != 0
             Log.error { "sgemm_accumulate failed with status #{status} for #{a.rows}x#{a.cols} * #{b.rows}x#{b.cols}" }
-            raise RuntimeError.new("CUDA.sgemm_accumulate failed with status #{status} for #{a.rows}x#{a.cols} * #{b.rows}x#{b.cols}")
+            # CPU fallback mirroring the regular `*` implementation
+            self.sync_from_device!("gemm_fallback") if device_dirty?
+            a.sync_from_device!("gemm_fallback") if a.device_dirty?
+            b.sync_from_device!("gemm_fallback") if b.device_dirty?
+            @rows.times do |i|
+              @cols.times do |j|
+                sum = 0.0
+                a.cols.times do |k|
+                  sum += a.unsafe_get(i, k) * b.unsafe_get(k, j)
+                end
+                val = alpha * sum + beta * self.unsafe_get(i, j)
+                self.unsafe_set(i, j, val)
+              end
+            end
+            self.sync_to_device!("gemm_fallback_result")
           end
         elsif a.precision == Precision::Bf16
           # CPU fallback when no suitable cuBLAS routine is available


### PR DESCRIPTION
## Summary
- handle `sgemm_accumulate` failures by falling back to CPU matrix multiplication

## Testing
- `LD_LIBRARY_PATH=/usr/local/cuda/lib64 LIBRARY_PATH=/usr/local/cuda/lib64 crystal spec spec/cuda_gemm_fp32_spec.cr:4 --verbose -Denable_cuda --error-trace`

------
https://chatgpt.com/codex/tasks/task_e_68738ced9a6c833192a6b15ec08d96a5