### PR TITLE
Handle FP32 softmax rows

### DIFF
--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -28,20 +28,33 @@ module SHAInet
           # Run the kernel
           case @precision
           when Precision::Fp16
-            CUDA.softmax_rows_fp16(rptr.as(Pointer(UInt16)),
+            CUDA.softmax_rows_fp16(
+              rptr.as(Pointer(UInt16)),
               dptr.as(Pointer(UInt16)),
               @rows,
-              @cols)
+              @cols
+            )
           when Precision::Bf16
-            CUDA.softmax_rows_bf16(rptr.as(Pointer(UInt16)),
+            CUDA.softmax_rows_bf16(
+              rptr.as(Pointer(UInt16)),
               dptr.as(Pointer(UInt16)),
               @rows,
-              @cols)
+              @cols
+            )
+          when Precision::Fp32
+            CUDA.softmax_rows_fp32(
+              rptr.as(Pointer(Float32)),
+              dptr.as(Pointer(Float32)),
+              @rows,
+              @cols
+            )
           else
-            CUDA.softmax_rows(rptr.as(Pointer(Float64)),
+            CUDA.softmax_rows(
+              rptr.as(Pointer(Float64)),
               dptr.as(Pointer(Float64)),
               @rows,
-              @cols)
+              @cols
+            )
           end
 
           # Mark result as having newer GPU data


### PR DESCRIPTION
## Summary
- support `Precision::Fp32` in `CudaMatrixExt#softmax_rows`
- keep existing FP16/BF16 codepaths and use FP64 kernels for FP64 only

## Testing
- `crystal spec -D enable_cuda --error-on-warnings` *(fails: CUDA memory allocation errors, PyTorch missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873a96a89148331a68d76f0a8c12772