### PR TITLE
Fix dropout_fp32 dispatch

### DIFF
--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -86,6 +86,11 @@ module SHAInet
               rptr.as(Pointer(UInt16)),
               dptr.as(Pointer(UInt16)),
               @rows, @cols, prob, seed)
+          when Precision::Fp32
+            CUDA.dropout_fp32(
+              rptr.as(Pointer(Float32)),
+              dptr.as(Pointer(Float32)),
+              @rows, @cols, prob, seed)
           else
             CUDA.dropout(
               rptr.as(Pointer(Float64)),


### PR DESCRIPTION
## Summary
- use CUDA.dropout_fp32 for FP32 precision in `CudaMatrixExt#dropout`

## Testing
- `crystal spec --no-color` *(fails: undefined method 'element_div_fp16')*

------
https://chatgpt.com/codex/tasks/task_e_6873a96db800833180961d7c0fc9bbab