### PR TITLE
Fix default precision in CUDA helpers

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -166,8 +166,8 @@ module SHAInet
         buf.to_unsafe.as(Pointer(Int32))[0] = value.round.to_i32
         buf
       else
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
         buf
       end
     end

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -254,7 +254,7 @@ module SHAInet
       when Precision::Int8
         LibCUDNN::CudnnDataType::CUDNN_DATA_INT8
       else
-        LibCUDNN::CudnnDataType::CUDNN_DATA_DOUBLE
+        LibCUDNN::CudnnDataType::CUDNN_DATA_FLOAT
       end
     end
 
@@ -279,8 +279,8 @@ module SHAInet
         buf.to_unsafe.as(Pointer(Int8))[0] = value.round.to_i8
         buf
       else
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
         buf
       end
     end


### PR DESCRIPTION
## Summary
- default unknown compute type scalars to FP32
- default cuDNN data type and scalar helper to FP32 instead of FP64

## Testing
- `crystal spec --order random`

------
https://chatgpt.com/codex/tasks/task_e_6873ca4a6d5083318caa963b3408868b