### PR TITLE
Add float32 support for cross-entropy CUDA kernels

### DIFF
--- a/build_cuda_kernels.sh
+++ b/build_cuda_kernels.sh
@@ -23,7 +23,7 @@ SRC_DIR="src/shainet/native"
 OUTPUT_LIB="libshainet_cuda_kernels.so"
 
 # Compilation flags
-NVCC_FLAGS="-shared --compiler-options=-fPIC -O3 -arch=sm_60"
+NVCC_FLAGS="-shared --compiler-options=-fPIC -O3 -arch=sm_60 -std=c++14"
 INCLUDE_FLAGS="-I${CUDA_PATH}/include"
 LIBRARY_FLAGS="-L${CUDA_PATH}/lib64 -lcurand"
 

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -1955,6 +1955,34 @@ module SHAInet
       end
     end
 
+    def cross_entropy_loss_gradient_fp32(predicted : Pointer(Float32), target : Pointer(Float32),
+                                         grad_output : Pointer(Float32), loss_output : Pointer(Float64),
+                                         rows : Int32, cols : Int32) : Int32
+      unless fn = @@cross_entropy_loss_grad_f32_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "cross_entropy_loss_gradient_f32")
+          unless sym.null?
+            @@cross_entropy_loss_grad_f32_proc = Proc(Pointer(Float32), Pointer(Float32), Pointer(Float32), Pointer(Float64), Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@cross_entropy_loss_grad_f32_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+
+      begin
+        loss_device = ensure_loss_buffer
+        fn.call(predicted, target, grad_output, loss_device, rows, cols)
+        CUDA.memcpy(loss_output.as(Pointer(Void)), loss_device.as(Pointer(Void)), 8_u64, MemcpyKind::DeviceToHost)
+        0
+      rescue e
+        Log.error { "CUDA Error in cross_entropy_loss_gradient_fp32: #{e}" }
+        1
+      end
+    end
+
     def softmax_cross_entropy_label(predicted : Pointer(Float64), labels : Pointer(Int32),
                                     grad_out : Pointer(Float64), loss_out : Pointer(Float64),
                                     rows : Int32, cols : Int32) : Int32
@@ -1983,6 +2011,34 @@ module SHAInet
       end
     end
 
+    def softmax_cross_entropy_label_fp32(predicted : Pointer(Float32), labels : Pointer(Int32),
+                                         grad_out : Pointer(Float32), loss_out : Pointer(Float64),
+                                         rows : Int32, cols : Int32) : Int32
+      unless fn = @@softmax_cross_entropy_label_f32_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "softmax_cross_entropy_label_f32")
+          unless sym.null?
+            @@softmax_cross_entropy_label_f32_proc = Proc(Pointer(Float32), Pointer(Int32), Pointer(Float32), Pointer(Float64), Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@softmax_cross_entropy_label_f32_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+
+      begin
+        loss_device = ensure_loss_buffer
+        fn.call(predicted, labels, grad_out, loss_device, rows, cols)
+        CUDA.memcpy(loss_out.as(Pointer(Void)), loss_device.as(Pointer(Void)), 8_u64, MemcpyKind::DeviceToHost)
+        0
+      rescue e
+        Log.error { "CUDA Error in softmax_cross_entropy_label_fp32: #{e}" }
+        1
+      end
+    end
+
     def softmax_cross_entropy_label_matrix(predicted : Pointer(Float64), labels : Pointer(Float64),
                                            grad_out : Pointer(Float64), loss_out : Pointer(Float64),
                                            rows : Int32, cols : Int32) : Int32
@@ -2007,6 +2063,34 @@ module SHAInet
         0
       rescue e
         Log.error { "CUDA Error in softmax_cross_entropy_label_matrix: #{e}" }
+        1
+      end
+    end
+
+    def softmax_cross_entropy_label_matrix_fp32(predicted : Pointer(Float32), labels : Pointer(Float32),
+                                                grad_out : Pointer(Float32), loss_out : Pointer(Float64),
+                                                rows : Int32, cols : Int32) : Int32
+      unless fn = @@softmax_cross_entropy_label_matrix_f32_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "softmax_cross_entropy_label_matrix_f32")
+          unless sym.null?
+            @@softmax_cross_entropy_label_matrix_f32_proc = Proc(Pointer(Float32), Pointer(Float32), Pointer(Float32), Pointer(Float64), Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@softmax_cross_entropy_label_matrix_f32_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+
+      begin
+        loss_device = ensure_loss_buffer
+        fn.call(predicted, labels, grad_out, loss_device, rows, cols)
+        CUDA.memcpy(loss_out.as(Pointer(Void)), loss_device.as(Pointer(Void)), 8_u64, MemcpyKind::DeviceToHost)
+        0
+      rescue e
+        Log.error { "CUDA Error in softmax_cross_entropy_label_matrix_fp32: #{e}" }
         1
       end
     end


### PR DESCRIPTION
## Summary
- templatize CUDA kernels for cross-entropy and softmax label computations
- add float32 entry points in `cuda.cr`
- compile kernels with `-std=c++14`

## Testing
- `crystal spec --order random -t spec/cross_entropy_cuda_precision_spec.cr`
- `bash build_cuda_kernels.sh` *(fails: nvcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873fdbfe8f08331afadd257e63b87f3