### PR TITLE
Update tests to use Fp32 values

### DIFF
--- a/spec/cross_entropy_cuda_precision_spec.cr
+++ b/spec/cross_entropy_cuda_precision_spec.cr
@@ -3,38 +3,38 @@ require "./spec_helper"
 describe "CUDA cross entropy precision checks" do
   it "raises for FP32 cross_entropy_loss_gradient" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
-    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
-    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
-    loss = 0.0
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    loss = 0.0_f32
     SHAInet::CUDNN.cross_entropy_loss_gradient(pred, target, pointerof(loss), grad)
   end
 
   it "raises for FP16 cross_entropy_loss_and_gradient" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    loss = 0.0
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    loss = 0.0_f32
     SHAInet::CUDNN.cross_entropy_loss_and_gradient(pred, target, pointerof(loss), grad)
   end
 
   it "raises for FP16 softmax_cross_entropy_loss_and_gradient" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    target = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    loss = 0.0
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    target = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    loss = 0.0_f32
     SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(pred, target, pointerof(loss), grad)
   end
 
   it "raises for FP16 softmax_cross_entropy_label_loss_and_gradient" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    pred = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    labels = SHAInet::CudaMatrix.new(1, 1, 0.0, SHAInet::Precision::Fp32)
-    grad = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
-    loss = 0.0
-    labels[0, 0] = 0.0
+    pred = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    labels = SHAInet::CudaMatrix.new(1, 1, 0.0_f32, SHAInet::Precision::Fp32)
+    grad = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    loss = 0.0_f32
+    labels[0, 0] = 0.0_f32
     SHAInet::CUDNN.softmax_cross_entropy_label_loss_and_gradient(pred, labels, pointerof(loss), grad)
   end
 end

--- a/spec/precision_spec.cr
+++ b/spec/precision_spec.cr
@@ -7,7 +7,7 @@ describe "Precision enum" do
     net.add_layer(:input, 1, SHAInet.none)
     net.add_layer(:output, 1, SHAInet.sigmoid)
     net.fully_connect
-    out = net.run([0.5])
+    out = net.run([0.5_f32])
     out.size.should eq(1)
   end
 
@@ -17,7 +17,7 @@ describe "Precision enum" do
     net.add_layer(:input, 1, SHAInet.none)
     net.add_layer(:output, 1, SHAInet.sigmoid)
     net.fully_connect
-    out = net.run([0.25])
+    out = net.run([0.25_f32])
     out.size.should eq(1)
   end
 
@@ -28,7 +28,7 @@ describe "Precision enum" do
     net.add_layer(:output, 1, SHAInet.sigmoid)
     net.fully_connect
     net.quantize_int8!
-    out = net.run([0.5])
+    out = net.run([0.5_f32])
     out.size.should eq(1)
   end
 
@@ -45,9 +45,9 @@ describe "Precision enum" do
 
   it "quantizes tensors and network weights" do
     m = SHAInet::SimpleMatrix.new(1, 3)
-    m[0, 0] = -1.0
-    m[0, 1] = 0.0
-    m[0, 2] = 1.0
+    m[0, 0] = -1.0_f32
+    m[0, 1] = 0.0_f32
+    m[0, 2] = 1.0_f32
     buf, scale, zp = SHAInet::Quantization.quantize_tensor(m)
     buf.size.should eq(3)
     SHAInet::Int8Value.new(buf[2]).to_f32(scale, zp).should be_close(1.0, scale)
@@ -67,17 +67,17 @@ describe "Precision enum" do
     (h.to_f32 - v).abs.should be < 0.01
   end
 
-  it "roundtrips Float64 values" do
-    v = 3.1415926535_f64
+  it "roundtrips Float32 precision values" do
+    v = 3.1415927_f32
     h = SHAInet::Float16.new(v)
-    (h.to_f64 - v).abs.should be < 0.01
+    (h.to_f32 - v).abs.should be < 0.01
   end
 
-  it "uses Float32/64 to_f16 helpers" do
+  it "uses Float32 to_f16 helpers" do
     h1 = 1.25_f32.to_f16
     (h1.to_f32 - 1.25_f32).abs.should be < 0.01
 
-    h2 = 1.25_f64.to_f16
-    (h2.to_f64 - 1.25_f64).abs.should be < 0.01
+    h2 = 1.25_f32.to_f16
+    (h2.to_f32 - 1.25_f32).abs.should be < 0.01
   end
 end


### PR DESCRIPTION
## Summary
- update `cross_entropy_cuda_precision_spec` to use Float32 constants
- update `precision_spec` to prefer Float32 values

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_6874b6fbecdc8331bcf9073dcdfd6a1d