### PR TITLE
Switch examples to float32 arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ end
 
 ### Raw data access
 
-`CudaMatrix#raw_data` provides the matrix values as an `Array(Float64)` for
+`CudaMatrix#raw_data` provides the matrix values as an `Array(Float32)` for
 convenience.  When the matrix uses half precision or INT8 storage this method
 allocates and converts the data.  Use `CudaMatrix#raw_data_buffer` to obtain a
 writable slice of the underlying CPU buffer without conversion.  Functions such

--- a/benchmarks/transformer_training_benchmark.cr
+++ b/benchmarks/transformer_training_benchmark.cr
@@ -16,10 +16,10 @@ ids = tokenizer.encode(text)
 token_count = tokenizer.vocab.size
 
 def build_training(ids, token_count)
-  training = [] of Array(Array(Array(Int32)) | Array(Float64))
+  training = [] of Array(Array(Array(Int32)) | Array(Float32))
   (0...ids.size - 1).each do |i|
     seq = [[ids[i]]]
-    target = Array(Float64).new(token_count, 0.0)
+    target = Array(Float32).new(token_count, 0.0_f32)
     target[ids[i + 1]] = 1.0
     training << [seq, target]
   end

--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -219,8 +219,8 @@ while (val_batch = val_data.next_batch(val_batch_size)).size > 0
     seq = input_ids.map { |id| [id] }
 
     # Convert target_id to one-hot vector for loss calculation
-    target = Array(Float64).new(token_count, 0.0)
-    target[target_id] = 1.0
+    target = Array(Float32).new(token_count, 0.0_f32)
+    target[target_id] = 1.0_f32
 
     output_vec = net.run(seq, return_matrix: true).as(SHAInet::CudaMatrix).to_a.last
 

--- a/examples/llm_sample.cr
+++ b/examples/llm_sample.cr
@@ -26,15 +26,15 @@ net.fully_connect
 
 # Helper to create one-hot vectors
 one_hot = ->(id : Int32, size : Int32) do
-  arr = Array(Float64).new(size, 0.0)
-  arr[id] = 1.0
+  arr = Array(Float32).new(size, 0.0_f32)
+  arr[id] = 1.0_f32
   arr
 end
 
 # Build training pairs: each token predicts the next token
-training = [] of Tuple(Array(Array(Float64)), Array(Float64))
+training = [] of Tuple(Array(Array(Float32)), Array(Float32))
 (0...ids.size - 1).each do |i|
-  input = [[ids[i].to_f64]]
+  input = [[ids[i].to_f32]]
   expected = one_hot.call(ids[i + 1], token_count)
   training << {input, expected}
 end

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -32,15 +32,15 @@ net.precision = SHAInet::Precision::Fp16 # or SHAInet::Precision::Bf16
 
 # Helper to create one-hot vectors
 one_hot = ->(id : Int32, size : Int32) do
-  arr = Array(Float64).new(size, 0.0)
-  arr[id] = 1.0
+  arr = Array(Float32).new(size, 0.0_f32)
+  arr[id] = 1.0_f32
   arr
 end
 
 # Each token predicts the next token
-training = [] of Tuple(Array(Array(Float64)), Array(Float64))
+training = [] of Tuple(Array(Array(Float32)), Array(Float32))
 (0...ids.size - 1).each do |i|
-  input = [[ids[i].to_f64]]
+  input = [[ids[i].to_f32]]
   expected = one_hot.call(ids[i + 1], token_count)
   training << {input, expected}
 end


### PR DESCRIPTION
## Summary
- update training examples to allocate `Array(Float32)` instead of `Array(Float64)`
- adjust helper functions and input conversions accordingly
- mention `Array(Float32)` as the default in the README

## Testing
- `crystal spec`

------
https://chatgpt.com/codex/tasks/task_e_6874b6fc406883318b658a8504983111