### PR TITLE
Drop remaining double precision helpers

### DIFF
--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -29,7 +29,6 @@ module SHAInet
       # Additional datatypes for half precision routines
       enum DataType
         CUDA_R_32F  =  0
-        CUDA_R_64F  =  1
         CUDA_R_16F  =  2
         CUDA_R_16BF = 14
         CUDA_R_8I   =  3
@@ -39,7 +38,6 @@ module SHAInet
       enum ComputeType
         CUBLAS_COMPUTE_16F  =  64
         CUBLAS_COMPUTE_32F  =  68
-        CUBLAS_COMPUTE_64F  =  70
         CUBLAS_COMPUTE_16BF = 119
         CUBLAS_COMPUTE_32I  =  82
       end
@@ -143,15 +141,11 @@ module SHAInet
 
     # Return a small typed buffer containing `value` for the given compute type.
     # The returned slice must be kept alive while passed to cuBLAS.
-    def scalar_for_compute_type(value : Float64, compute_type : LibCUBLAS::ComputeType) : Bytes
+    def scalar_for_compute_type(value : Float32, compute_type : LibCUBLAS::ComputeType) : Bytes
       case compute_type
-      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
-        buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32F
         buf = Bytes.new(sizeof(Float32))
-        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16F
         buf = Bytes.new(sizeof(Float16))
@@ -159,7 +153,7 @@ module SHAInet
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
         buf = Bytes.new(sizeof(BFloat16))
-        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value)
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I
         buf = Bytes.new(sizeof(Int32))
@@ -167,7 +161,7 @@ module SHAInet
         buf
       else
         buf = Bytes.new(sizeof(Float32))
-        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       end
     end
@@ -490,11 +484,6 @@ module SHAInet
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
         alpha = SHAInet::BFloat16.new(1.0_f32)
         beta = SHAInet::BFloat16.new(0.0_f32)
-        alpha_ptr = pointerof(alpha).as(Void*)
-        beta_ptr = pointerof(beta).as(Void*)
-      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
-        alpha = 1.0_f64
-        beta = 0.0_f64
         alpha_ptr = pointerof(alpha).as(Void*)
         beta_ptr = pointerof(beta).as(Void*)
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -58,7 +58,6 @@ module SHAInet
 
       enum DataType
         CUDA_R_32F  =  0
-        CUDA_R_64F  =  1
         CUDA_R_16F  =  2
         CUDA_R_16BF = 14
         CUDA_R_8I   =  3
@@ -68,7 +67,6 @@ module SHAInet
       enum ComputeType
         CUBLAS_COMPUTE_16F  =  64
         CUBLAS_COMPUTE_32F  =  68
-        CUBLAS_COMPUTE_64F  =  70
         CUBLAS_COMPUTE_16BF = 119
         CUBLAS_COMPUTE_32I  =  82
       end
@@ -124,15 +122,11 @@ module SHAInet
 
     # Provide a typed scalar buffer matching the given compute type so
     # routines relying on cuBLAS APIs can compile when CUDA is disabled.
-    def scalar_for_compute_type(value : Float64, compute_type : LibCUBLAS::ComputeType) : Bytes
+    def scalar_for_compute_type(value : Float32, compute_type : LibCUBLAS::ComputeType) : Bytes
       case compute_type
-      when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_64F
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
-        buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32F
         buf = Bytes.new(sizeof(Float32))
-        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16F
         buf = Bytes.new(sizeof(Float16))
@@ -140,15 +134,15 @@ module SHAInet
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_16BF
         buf = Bytes.new(sizeof(BFloat16))
-        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value)
         buf
       when LibCUBLAS::ComputeType::CUBLAS_COMPUTE_32I
         buf = Bytes.new(sizeof(Int32))
         buf.to_unsafe.as(Pointer(Int32))[0] = value.round.to_i32
         buf
       else
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       end
     end
@@ -552,11 +546,11 @@ module SHAInet
       Pointer(Void).null
     end
 
-    def typed_scalar(value : Float64, precision : Precision) : Bytes
+    def typed_scalar(value : Float32, precision : Precision) : Bytes
       case precision
       when Precision::Fp32
         buf = Bytes.new(sizeof(Float32))
-        buf.to_unsafe.as(Pointer(Float32))[0] = value.to_f32
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       when Precision::Fp16
         buf = Bytes.new(sizeof(Float16))
@@ -564,15 +558,15 @@ module SHAInet
         buf
       when Precision::Bf16
         buf = Bytes.new(sizeof(BFloat16))
-        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value.to_f32)
+        buf.to_unsafe.as(Pointer(BFloat16))[0] = BFloat16.new(value)
         buf
       when Precision::Int8
         buf = Bytes.new(sizeof(Int8))
         buf.to_unsafe.as(Pointer(Int8))[0] = value.round.to_i8
         buf
       else
-        buf = Bytes.new(sizeof(Float64))
-        buf.to_unsafe.as(Pointer(Float64))[0] = value
+        buf = Bytes.new(sizeof(Float32))
+        buf.to_unsafe.as(Pointer(Float32))[0] = value
         buf
       end
     end

--- a/src/shainet/math/functions.cr
+++ b/src/shainet/math/functions.cr
@@ -160,14 +160,14 @@ module SHAInet
   end
 
   def self._swiglu(value : GenNum) : Float64
-    v = value.to_f64
-    v * _sigmoid(v)
+    v = value.to_f32
+    v.to_f64 * _sigmoid(v)
   end
 
   def self._swiglu_prime(value : GenNum) : Float64
-    v = value.to_f64
+    v = value.to_f32
     s = _sigmoid(v)
-    s + v * s * (1.0 - s)
+    s + v.to_f64 * s * (1.0 - s)
   end
 
   ##################################################################

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -21,7 +21,7 @@ module SHAInet
       @embeddings = mat_klass.new(vocab_size, l_size)
       vocab_size.times do |r|
         l_size.times do |c|
-          @embeddings[r, c] = rand(-0.1..0.1)
+          @embeddings[r, c] = rand(-0.1..0.1).to_f32
         end
       end
       @gradients = mat_klass.zeros(vocab_size, l_size)


### PR DESCRIPTION
## Summary
- remove CUDA double-precision enums
- drop Float64 scalar paths
- update cuDNN helpers for Float32 inputs
- fix embedding initialization and swiglu helpers

## Testing
- `./build_cuda_kernels.sh`
- `crystal spec` *(fails: expected argument #1 to `SHAInet::SimpleMatrix.from_a` to be Array(Array(Float32 | Int32 | Int64 | SHAInet::BFloat16 | SHAInet::Float16)), not Array(Array(Float64))*

------
https://chatgpt.com/codex/tasks/task_e_6874e3116d9483319a1517f3a7cc7e58