### PR TITLE
Switch network params and outputs to Float32

### DIFF
--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -45,7 +45,7 @@ epochs = 100
 batch = 800
 # Learning rate for the AdamW optimizer.
 # A smaller learning rate can help with stability, especially for larger models.
-learning_rate = 0.0005
+learning_rate = 0.0005_f32
 # log_each: How often to log training progress.
 log_each = 1
 # val_batch_size: Batch size for validation.
@@ -184,9 +184,13 @@ while (val_batch = val_data.next_batch(val_batch_size)).size > 0
     input_ids = case input_raw
                 when Array(Int32)
                   input_raw
+                when Array(Array(Float32))
+                  input_raw.map { |row| row[0].to_i }
                 when Array(Array(Float64))
                   input_raw.map { |row| row[0].to_i }
                 when Array(Float64)
+                  input_raw.map(&.to_i)
+                when Array(Float32)
                   input_raw.map(&.to_i)
                 when SHAInet::CudaMatrix
                   input_raw.to_a.map { |row| row[0].to_i }
@@ -200,8 +204,13 @@ while (val_batch = val_data.next_batch(val_batch_size)).size > 0
     target_id = case target_raw
                 when Int32
                   target_raw
+                when Array(Float32)
+                  target_raw.index(target_raw.max) || 0
                 when Array(Float64)
                   target_raw.index(target_raw.max) || 0
+                when Array(Array(Float32))
+                  flat = target_raw.flatten
+                  flat.index(flat.max) || 0
                 when Array(Array(Float64))
                   flat = target_raw.flatten
                   flat.index(flat.max) || 0

--- a/examples/llm_sample.cr
+++ b/examples/llm_sample.cr
@@ -42,7 +42,7 @@ end
 # Convert tuples to arrays for training
 train_data = training.map { |seq, target| [seq, target] }
 
-net.learning_rate = 0.1
+net.learning_rate = 0.1_f32
 net.train(data: train_data,
   training_type: :sgdm,
   cost_function: :c_ent,

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -48,7 +48,7 @@ end
 # Convert tuples to arrays for training
 train_data = training.map { |seq, target| [seq, target] }
 
-net.learning_rate = 0.001
+net.learning_rate = 0.001_f32
 net.train(data: train_data,
   training_type: :adamw,
   cost_function: :c_ent,

--- a/spec/accumulation_spec.cr
+++ b/spec/accumulation_spec.cr
@@ -13,7 +13,7 @@ describe "Gradient accumulation" do
       net.add_layer(:input, 1, SHAInet.sigmoid)
       net.add_layer(:output, 1, SHAInet.sigmoid)
       net.fully_connect
-      net.learning_rate = 0.1
+      net.learning_rate = 0.1_f32
       net
     }
 

--- a/spec/cached_inference_spec.cr
+++ b/spec/cached_inference_spec.cr
@@ -18,7 +18,7 @@ describe "Transformer cached inference" do
     seq = [1, 2, 3]
 
     tl = net.hidden_layers.find(&.is_a?(SHAInet::TransformerLayer)).as(SHAInet::TransformerLayer)
-    outputs_full = [] of Array(Float64)
+    outputs_full = [] of Array(Float32)
     seq.each_index do |i|
       prefix = seq[0..i]
       tl.mask = SHAInet::TransformerMaskUtils.causal_mask(prefix.size)
@@ -33,7 +33,7 @@ describe "Transformer cached inference" do
       end
     end
 
-    cached = [] of Array(Float64)
+    cached = [] of Array(Float32)
     first_key_id = nil
     seq.each_with_index do |t, idx|
       out = net.run_cached(t, reset_cache: idx.zero?)

--- a/spec/decoding_spec.cr
+++ b/spec/decoding_spec.cr
@@ -4,7 +4,7 @@ describe SHAInet do
   it "samples from top_k distribution" do
     rng = Random::DEFAULT
     rng.new_seed(1_u64, 1_u64)
-    logits = [0.1, 0.2, 0.3, 0.4]
+    logits = [0.1_f32, 0.2_f32, 0.3_f32, 0.4_f32]
     res = SHAInet.top_k_sample(logits, 2, rng: rng)
     [2, 3].includes?(res).should eq(true)
   end
@@ -12,7 +12,7 @@ describe SHAInet do
   it "samples from top_p distribution" do
     rng = Random::DEFAULT
     rng.new_seed(1_u64, 1_u64)
-    logits = [0.5, 0.3, 0.1, 0.1]
+    logits = [0.5_f32, 0.3_f32, 0.1_f32, 0.1_f32]
     SHAInet.top_p_sample(logits, 0.6, rng: rng).should eq(0)
   end
 end

--- a/spec/lr_scheduler_spec.cr
+++ b/spec/lr_scheduler_spec.cr
@@ -6,7 +6,7 @@ describe "Learning rate scheduler" do
     net.add_layer(:input, 1)
     net.add_layer(:output, 1)
     net.fully_connect
-    net.learning_rate = 1.0
+    net.learning_rate = 1.0_f32
     net.warmup_steps = 2
     net.decay_type = :step
     net.decay_rate = 0.5

--- a/spec/network_save_load_spec.cr
+++ b/spec/network_save_load_spec.cr
@@ -10,8 +10,8 @@ describe SHAInet::Network do
     net.add_layer(:output, 1, SHAInet.sigmoid)
     net.fully_connect
     net.add_residual(0, 1)
-    net.learning_rate = 0.01
-    net.momentum = 0.9
+    net.learning_rate = 0.01_f32
+    net.momentum = 0.9_f32
     net.precision = SHAInet::Precision::Fp32
     net.warmup_steps = 5
     net.decay_type = :step

--- a/spec/transformer_integration_spec.cr
+++ b/spec/transformer_integration_spec.cr
@@ -79,15 +79,15 @@ describe "Transformer Integration" do
       net.transformer_layers.first.positional_encoding = pos_enc
 
       # Create training data with proper sequence format
-      training_data = [] of Array(Array(Float64) | Array(Array(Float64)))
+      training_data = [] of Array(Array(Float32) | Array(Array(Float32)))
       (0...(ids.size - seq_len)).each do |i|
-        seq = ids[i, seq_len].map { |id| [id.to_f64] }
-        target = [ids[i + seq_len].to_f64]
+        seq = ids[i, seq_len].map { |id| [id.to_f32] }
+        target = [ids[i + seq_len].to_f32]
         training_data << [seq, target]
       end
 
       # Training should not crash - but limit to one epoch and small batch for test
-      net.learning_rate = 0.1
+      net.learning_rate = 0.1_f32
       # We're now able to handle training without errors, so this shouldn't raise an exception
       net.train(
         data: training_data,
@@ -131,9 +131,9 @@ describe "Transformer Integration" do
 
       # Output may be a vector for the last token or a matrix with one row per
       # token. Verify we received some scores with the vocabulary dimension.
-      if output.is_a?(Array(Array(Float64)))
+      if output.is_a?(Array(Array(Float32)))
         output.first.size.should eq(token_count)
-      elsif output.is_a?(Array(Float64))
+      elsif output.is_a?(Array(Float32))
         output.size.should eq(token_count)
       end
     end
@@ -206,12 +206,12 @@ describe "Transformer Integration" do
       first_input = batch[0][0]
       first_output = batch[0][1]
 
-      first_input.should be_a(Array(Array(Float64)))
-      first_input.as(Array(Array(Float64))).size.should eq(3)    # Sequence length
-      first_input.as(Array(Array(Float64)))[0].size.should eq(1) # Each token is wrapped in array
+      first_input.should be_a(Array(Array(Float32)))
+      first_input.as(Array(Array(Float32))).size.should eq(3)    # Sequence length
+      first_input.as(Array(Array(Float32)))[0].size.should eq(1) # Each token is wrapped in array
 
-      first_output.should be_a(Array(Float64))
-      first_output.as(Array(Float64)).size.should eq(1)
+      first_output.should be_a(Array(Float32))
+      first_output.as(Array(Float32)).size.should eq(1)
 
       # Clean up
       File.delete(temp_file)

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -190,7 +190,7 @@ describe "Network with TransformerLayer" do
     net.add_layer(:output, 2, SHAInet.none)
     net.fully_connect
     training = [[[[1.0, 0.0]], [1.0, 1.0]]]
-    net.learning_rate = 0.005
+    net.learning_rate = 0.005_f32
 
     # Reduced epochs to avoid memory issues and hanging
     net.train(data: training, training_type: :sgdm,


### PR DESCRIPTION
## Summary
- refactor Network fields to Float32 and update run methods
- adjust serialization/deserialization for new formats
- update inference helpers for Float32 logits
- tweak examples and specs for Float32

## Testing
- `crystal spec --order=random` *(fails: "SHAInet::SimpleMatrix#[]=" type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6874f3ef2cc08331bd2f1aa6f07e1e7a