### PR TITLE
Fix tokenizer float32 encoding

### DIFF
--- a/src/shainet/text/tokenizer.cr
+++ b/src/shainet/text/tokenizer.cr
@@ -41,7 +41,7 @@ module SHAInet
     def encode_matrix(text : String)
       ids = encode(text)
       mat_klass = CUDA.fully_available? ? CudaMatrix : SimpleMatrix
-      mat_klass.from_a([ids.map(&.to_f64)])
+      mat_klass.from_a([ids.map(&.to_f32)])
     end
 
     # Convert an array of token IDs back to their corresponding words. Unknown

--- a/src/shainet/transformer/mask_utils.cr
+++ b/src/shainet/transformer/mask_utils.cr
@@ -7,7 +7,7 @@ module SHAInet
       mask = SimpleMatrix.zeros(size, size)
       size.times do |i|
         i.times do |j|
-          mask[i, j] = -1e9
+          mask[i, j] = -1e9_f32
         end
       end
       mask
@@ -23,7 +23,7 @@ module SHAInet
       batch.times do |i|
         len = lengths[i]
         len.upto(max_len - 1) do |j|
-          mask[i, j] = -1e9
+          mask[i, j] = -1e9_f32
         end
       end
       mask


### PR DESCRIPTION
## Summary
- convert token IDs to `Float32` in `Tokenizer.encode_matrix`
- use `-1e9_f32` in transformer mask utils

## Testing
- `crystal spec --order=random` *(fails: expected argument #3 to `SHAInet::CudaMatrix#[]=` to be Float32)*

------
https://chatgpt.com/codex/tasks/task_e_6874ffd9d84c8331b1efccd0662702de