### PR TITLE
Remove FP64 docs mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ SHAInet (Super Human Artificial Intelligence Network) is a neural network librar
 - Residual skip connections between layers
 - PyTorch and HuggingFace model import
 - Transformer and modern NLP support
-- Configurable precision (fp64/fp32/fp16/bf16/int8)
+- Configurable precision (fp32/fp16/bf16/int8)
 - Includes lightweight Float16/BFloat16 wrappers for half precision
-- GPU transpose kernels support FP64, FP32, FP16 and BF16
+- GPU transpose kernels support FP32, FP16 and BF16
 - Supports INT8 quantization for efficient inference
 - Enable half precision by setting `net.precision = SHAInet::Precision::Fp16`
   or `SHAInet::Precision::Bf16`.


### PR DESCRIPTION
## Summary
- drop fp64 from configurable precision features
- update kernel feature notes to remove fp64

## Testing
- `make test` *(fails: missing separator)*
- `crystal spec --fail-fast` *(fails: expected argument to be Array(Float64))*

------
https://chatgpt.com/codex/tasks/task_e_68750b7d4e288331b4282d3d4737abfe