### PR TITLE
Remove deprecated double precision CUDA paths

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -458,10 +458,6 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
-    def mse_cost_gradient(*args)
-      raise "CUDA kernels not available"
-    end
-
     def mse_cost_gradient_fp32(*args)
       raise "CUDA kernels not available"
     end

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1881,7 +1881,7 @@ module SHAInet
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)
           else
-            CUDA.dropout(
+            CUDA.dropout_fp32(
               dptr.as(Pointer(Float32)),
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)

--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -105,7 +105,7 @@ module SHAInet
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)
           else
-            CUDA.dropout(
+            CUDA.dropout_fp32(
               rptr.as(Pointer(Float32)),
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)


### PR DESCRIPTION
## Summary
- drop CUDA MSE fp64 kernel support and related loader
- route dropout helpers to fp32-only kernels
- update fallback calls in CUDA matrix helpers
- switch cublas wrappers from `cublasD*` to `cublasS*`
- remove unused API from CUDA stub

## Testing
- `crystal spec` *(fails: no overload matches 'Proc((Float32 | Int32 | SHAInet::BFloat16 | SHAInet::Float16), Tuple(Float32, Float32))#call' with type Float64)*

------
https://chatgpt.com/codex/tasks/task_e_68750ba5385c83318e7301e72d21ff09