### PR TITLE
Update spec comments for precision

### DIFF
--- a/spec/axpy_compute_type_spec.cr
+++ b/spec/axpy_compute_type_spec.cr
@@ -44,7 +44,7 @@ describe "CUDA.axpy_ex compute type" do
 end
 
 describe "CUDA.gemm_ex compute type" do
-  it "passes compute_type_for value for fp16 and fp64" do
+  it "passes compute_type_for value for fp16 and fp32" do
     handle = Pointer(Void).null.as(SHAInet::CUDA::LibCUBLAS::Handle)
 
     dtype = SHAInet::CUDA.data_type_for(SHAInet::Precision::Fp16)

--- a/spec/softmax_cross_entropy_cuda_spec.cr
+++ b/spec/softmax_cross_entropy_cuda_spec.cr
@@ -58,7 +58,8 @@ describe "CUDA softmax cross entropy" do
     target = SHAInet::SimpleMatrix.from_a([[0.0, 1.0]], SHAInet::Precision::Fp16)
     g_pred = SHAInet::GPUMemory.to_gpu(logits).as(SHAInet::CudaMatrix)
     g_target = SHAInet::GPUMemory.to_gpu(target).as(SHAInet::CudaMatrix)
-    grad = SHAInet::CudaMatrix.new(logits.rows, logits.cols) # fp64 by default
+    # workspace uses Fp32 precision
+    grad = SHAInet::CudaMatrix.new(logits.rows, logits.cols, precision: SHAInet::Precision::Fp32)
     loss_val = 0.0
     expect_raises(Exception) do
       SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(g_pred, g_target, pointerof(loss_val), grad)


### PR DESCRIPTION
## Summary
- clarify workspace precision in softmax cross entropy CUDA spec
- rename compute type example description in AXPY spec
- clean up `fp64` mentions in specs

## Testing
- `crystal spec spec/axpy_compute_type_spec.cr`

------
https://chatgpt.com/codex/tasks/task_e_68750bb58530833196560f6814ce9505