### PR TITLE
Convert float literals in specs to Float32

### DIFF
--- a/spec/accumulation_spec.cr
+++ b/spec/accumulation_spec.cr
@@ -4,8 +4,8 @@ describe "Gradient accumulation" do
   it "matches larger batch training" do
     Random::DEFAULT.new_seed(42_u64)
     data = [
-      [[0.0], [0.0]],
-      [[1.0], [1.0]],
+      [[0.0_f32], [0.0_f32]],
+      [[1.0_f32], [1.0_f32]],
     ]
 
     build_net = -> {
@@ -46,7 +46,7 @@ describe "Gradient accumulation" do
     w_batch = net_batch.output_layers.last.weights[0, 0]
     b_batch = net_batch.output_layers.last.biases[0, 0]
 
-    w_acc.should be_close(w_batch, 1e-6)
-    b_acc.should be_close(b_batch, 1e-6)
+    w_acc.should be_close(w_batch, 1e-6_f32)
+    b_acc.should be_close(b_batch, 1e-6_f32)
   end
 end

--- a/spec/autograd_numerical_spec.cr
+++ b/spec/autograd_numerical_spec.cr
@@ -1,18 +1,18 @@
 require "./spec_helper"
 
 private def f(x : Float32)
-  x * x + 3.0
+  x * x + 3.0_f32
 end
 
 describe SHAInet::Autograd::Tensor do
   it "matches numerical gradient" do
-    x = SHAInet::Autograd::Tensor.new(2.0)
+    x = SHAInet::Autograd::Tensor.new(2.0_f32)
     y = x * x + 3
     y.backward
     autograd_grad = x.grad
 
-    h = 1e-6
+    h = 1e-6_f32
     numeric = (f(x.data + h) - f(x.data - h)) / (2*h)
-    autograd_grad.should be_close(numeric, 1e-6)
+    autograd_grad.should be_close(numeric, 1e-6_f32)
   end
 end

--- a/spec/autograd_tensor_spec.cr
+++ b/spec/autograd_tensor_spec.cr
@@ -2,23 +2,23 @@ require "./spec_helper"
 
 describe SHAInet::Autograd::Tensor do
   it "computes gradients for simple operations" do
-    a = SHAInet::Autograd::Tensor.new(2.0)
-    b = SHAInet::Autograd::Tensor.new(3.0)
+    a = SHAInet::Autograd::Tensor.new(2.0_f32)
+    b = SHAInet::Autograd::Tensor.new(3.0_f32)
     c = a * b + a
     c.backward
 
-    a.grad.should eq(3.0 + 1.0)
-    b.grad.should eq(2.0)
-    c.grad.should eq(1.0)
+    a.grad.should eq(3.0_f32 + 1.0_f32)
+    b.grad.should eq(2.0_f32)
+    c.grad.should eq(1.0_f32)
   end
 
   it "computes gradients for matrix multiply" do
-    x = SHAInet::Autograd::Tensor.new(2.0)
-    y = SHAInet::Autograd::Tensor.new(4.0)
+    x = SHAInet::Autograd::Tensor.new(2.0_f32)
+    y = SHAInet::Autograd::Tensor.new(4.0_f32)
     z = x.matmul(y)
     z.backward
 
-    x.grad.should eq(4.0)
-    y.grad.should eq(2.0)
+    x.grad.should eq(4.0_f32)
+    y.grad.should eq(2.0_f32)
   end
 end

--- a/spec/autosave_spec.cr
+++ b/spec/autosave_spec.cr
@@ -10,8 +10,8 @@ describe SHAInet::Network do
     net.fully_connect
 
     data = [
-      [[0.0, 0.0], [0.0]],
-      [[1.0, 0.0], [1.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
     ]
 
     dir = "/tmp/auto_save_test"

--- a/spec/batch_processor_spec.cr
+++ b/spec/batch_processor_spec.cr
@@ -6,8 +6,8 @@ describe SHAInet::BatchProcessor do
     layer1 = SHAInet::MatrixLayer.new(2, 3)
     layer2 = SHAInet::MatrixLayer.new(2, 3)
 
-    input1 = mat_klass.from_a([[1.0, 2.0]])
-    input2 = mat_klass.from_a([[3.0, 4.0]])
+    input1 = mat_klass.from_a([[1.0_f32, 2.0_f32]])
+    input2 = mat_klass.from_a([[3.0_f32, 4.0_f32]])
 
     out1 = layer1.forward(input1)
     out2 = layer2.forward(input2)
@@ -20,7 +20,7 @@ describe SHAInet::BatchProcessor do
       result = batch_out[idx]
       expected.rows.times do |i|
         expected.cols.times do |j|
-          result[i, j].should be_close(expected[i, j], 1e-6)
+          result[i, j].should be_close(expected[i, j], 1e-6_f32)
         end
       end
     end

--- a/spec/bpe_tokenizer_detailed_spec.cr
+++ b/spec/bpe_tokenizer_detailed_spec.cr
@@ -75,7 +75,7 @@ describe "BPE Tokenizer Detailed Tests" do
       # Note: BPE might create slightly more tokens than requested due to individual characters
       # This is expected behavior - vocab_size is more of a target than a hard limit
       tokenizer.vocab.size.should be > 0
-      tokenizer.vocab.size.should be < (vocab_size * 1.5) # Allow some flexibility
+      tokenizer.vocab.size.should be < (vocab_size * 1.5_f32) # Allow some flexibility
     end
 
     it "should create consistent encodings" do

--- a/spec/cached_inference_spec.cr
+++ b/spec/cached_inference_spec.cr
@@ -46,7 +46,7 @@ describe "Transformer cached inference" do
 
     outputs_full.each_with_index do |o, i|
       o.each_with_index do |val, j|
-        val.should be_close(cached[i][j], 1e-2)
+        val.should be_close(cached[i][j], 1e-2_f32)
       end
     end
 

--- a/spec/cross_entropy_spec.cr
+++ b/spec/cross_entropy_spec.cr
@@ -2,24 +2,24 @@ require "./spec_helper"
 
 describe SHAInet do
   it "computes cross entropy cost derivative for expected 1" do
-    expected = 1.0
-    actual = 0.8
-    eps = 1e-6
+    expected = 1.0_f32
+    actual = 0.8_f32
+    eps = 1e-6_f32
     forward = SHAInet._cross_entropy_cost(expected, actual + eps)
     backward = SHAInet._cross_entropy_cost(expected, actual - eps)
     numeric = (forward - backward) / (2 * eps)
     formula = SHAInet._cross_entropy_cost_derivative(expected, actual)
-    formula.should be_close(numeric, 1e-5)
+    formula.should be_close(numeric, 1e-5_f32)
   end
 
   it "computes cross entropy cost derivative for expected 0" do
-    expected = 0.0
-    actual = 0.2
-    eps = 1e-6
+    expected = 0.0_f32
+    actual = 0.2_f32
+    eps = 1e-6_f32
     forward = SHAInet._cross_entropy_cost(expected, actual + eps)
     backward = SHAInet._cross_entropy_cost(expected, actual - eps)
     numeric = (forward - backward) / (2 * eps)
     formula = SHAInet._cross_entropy_cost_derivative(expected, actual)
-    formula.should be_close(numeric, 1e-5)
+    formula.should be_close(numeric, 1e-5_f32)
   end
 end

--- a/spec/cuda_copy_fp16_spec.cr
+++ b/spec/cuda_copy_fp16_spec.cr
@@ -9,7 +9,7 @@ describe "CUDA copy_device_to_device FP16" do
 
     4.times do |i|
       src[0, i] = (i + 1).to_f
-      dst[0, i] = 0.0
+      dst[0, i] = 0.0_f32
     end
 
     src.sync_to_device!

--- a/spec/cuda_dropout_inplace_spec.cr
+++ b/spec/cuda_dropout_inplace_spec.cr
@@ -4,18 +4,18 @@ describe "CUDA dropout! in-place" do
   it "masks values on the GPU" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
 
-    mat = SHAInet::CudaMatrix.new(32, 32, 0.0, SHAInet::Precision::Fp16)
-    mat.fill!(1.0)
+    mat = SHAInet::CudaMatrix.new(32, 32, 0.0_f32, SHAInet::Precision::Fp16)
+    mat.fill!(1.0_f32)
 
     # Apply dropout in-place without CPU sync
-    mat.dropout!(0.5)
+    mat.dropout!(0.5_f32)
 
     # GPU memory should now contain zeros in some positions
     mat.sync_from_device!
     zero_count = 0
     mat.rows.times do |i|
       mat.cols.times do |j|
-        zero_count += 1 if mat[i, j] == 0.0
+        zero_count += 1 if mat[i, j] == 0.0_f32
       end
     end
     zero_count.should be > 0

--- a/spec/cuda_element_add_spec.cr
+++ b/spec/cuda_element_add_spec.cr
@@ -3,35 +3,35 @@ require "./spec_helper"
 describe "CUDA element-wise addition" do
   it "adds fp16 matrices" do
     pending! "cuDNN not available" unless SHAInet::CUDNN.available?
-    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
-    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
-    a[0, 0] = 1.0; a[0, 1] = 2.0; a[1, 0] = 3.0; a[1, 1] = 4.0
-    b[0, 0] = 4.0; b[0, 1] = 3.0; b[1, 0] = 2.0; b[1, 1] = 1.0
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp16)
+    a[0, 0] = 1.0_f32; a[0, 1] = 2.0_f32; a[1, 0] = 3.0_f32; a[1, 1] = 4.0_f32
+    b[0, 0] = 4.0_f32; b[0, 1] = 3.0_f32; b[1, 0] = 2.0_f32; b[1, 1] = 1.0_f32
 
-    result = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
+    result = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp16)
     SHAInet::CUDNN.element_add!(result, a, b)
     result.sync_from_device!
 
-    result[0, 0].should be_close(5.0, 1e-2)
-    result[0, 1].should be_close(5.0, 1e-2)
-    result[1, 0].should be_close(5.0, 1e-2)
-    result[1, 1].should be_close(5.0, 1e-2)
+    result[0, 0].should be_close(5.0_f32, 1e-2_f32)
+    result[0, 1].should be_close(5.0_f32, 1e-2_f32)
+    result[1, 0].should be_close(5.0_f32, 1e-2_f32)
+    result[1, 1].should be_close(5.0_f32, 1e-2_f32)
   end
 
   it "adds bf16 matrices" do
     pending! "cuDNN not available" unless SHAInet::CUDNN.available?
-    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
-    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
-    a[0, 0] = 1.0; a[0, 1] = 2.0; a[1, 0] = 3.0; a[1, 1] = 4.0
-    b[0, 0] = 4.0; b[0, 1] = 3.0; b[1, 0] = 2.0; b[1, 1] = 1.0
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Bf16)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Bf16)
+    a[0, 0] = 1.0_f32; a[0, 1] = 2.0_f32; a[1, 0] = 3.0_f32; a[1, 1] = 4.0_f32
+    b[0, 0] = 4.0_f32; b[0, 1] = 3.0_f32; b[1, 0] = 2.0_f32; b[1, 1] = 1.0_f32
 
-    result = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Bf16)
+    result = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Bf16)
     SHAInet::CUDNN.element_add!(result, a, b)
     result.sync_from_device!
 
-    result[0, 0].should be_close(5.0, 1e-2)
-    result[0, 1].should be_close(5.0, 1e-2)
-    result[1, 0].should be_close(5.0, 1e-2)
-    result[1, 1].should be_close(5.0, 1e-2)
+    result[0, 0].should be_close(5.0_f32, 1e-2_f32)
+    result[0, 1].should be_close(5.0_f32, 1e-2_f32)
+    result[1, 0].should be_close(5.0_f32, 1e-2_f32)
+    result[1, 1].should be_close(5.0_f32, 1e-2_f32)
   end
 end

--- a/spec/cuda_element_div_spec.cr
+++ b/spec/cuda_element_div_spec.cr
@@ -3,15 +3,15 @@ require "./spec_helper"
 describe "CUDA element-wise division" do
   it "matches CPU division and handles divide by zero" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    a = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[4.0, 8.0], [3.0, 6.0]]))
-    b = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[2.0, 0.0], [3.0, 2.0]]))
+    a = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[4.0_f32, 8.0_f32], [3.0_f32, 6.0_f32]]))
+    b = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[2.0_f32, 0.0_f32], [3.0_f32, 2.0_f32]]))
 
     result = a.as(SHAInet::CudaMatrix) / b.as(SHAInet::CudaMatrix)
     result.sync_from_device!
 
-    result[0, 0].should eq(2.0)
-    result[0, 1].should eq(0.0)
-    result[1, 0].should eq(1.0)
-    result[1, 1].should eq(3.0)
+    result[0, 0].should eq(2.0_f32)
+    result[0, 1].should eq(0.0_f32)
+    result[1, 0].should eq(1.0_f32)
+    result[1, 1].should eq(3.0_f32)
   end
 end

--- a/spec/cuda_element_log_spec.cr
+++ b/spec/cuda_element_log_spec.cr
@@ -5,7 +5,7 @@ describe "CUDA element_log" do
     ENV.delete("SHAINET_DISABLE_CUDA")
     pending! "CUDA kernels not available" unless SHAInet::CUDA.kernels_available?
 
-    cpu = SHAInet::SimpleMatrix.from_a([[0.5, 1.0], [2.0, 4.0]])
+    cpu = SHAInet::SimpleMatrix.from_a([[0.5_f32, 1.0_f32], [2.0_f32, 4.0_f32]])
     gpu = SHAInet::GPUMemory.to_gpu(cpu)
 
     gpu_out = SHAInet::CudaMatrix.new(cpu.rows, cpu.cols)
@@ -21,7 +21,7 @@ describe "CUDA element_log" do
 
     cpu.rows.times do |i|
       cpu.cols.times do |j|
-        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6)
+        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/cuda_fp32_kernels_spec.cr
+++ b/spec/cuda_fp32_kernels_spec.cr
@@ -4,28 +4,28 @@ describe "CUDA FP32 kernels" do
   it "computes softmax_rows! on FP32" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
     cpu = SHAInet::SimpleMatrix.new(2, 3, precision: SHAInet::Precision::Fp32)
-    cpu[0, 0] = 0.5; cpu[0, 1] = 1.5; cpu[0, 2] = 2.5
-    cpu[1, 0] = 3.0; cpu[1, 1] = 0.0; cpu[1, 2] = -1.0
+    cpu[0, 0] = 0.5_f32; cpu[0, 1] = 1.5_f32; cpu[0, 2] = 2.5_f32
+    cpu[1, 0] = 3.0_f32; cpu[1, 1] = 0.0_f32; cpu[1, 2] = -1.0_f32
     expected = SHAInet.softmax_rows(cpu)
     gpu = SHAInet::GPUMemory.to_gpu(cpu).as(SHAInet::CudaMatrix)
     gpu.softmax_rows!
     gpu.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        gpu[i, j].to_f.should be_close(expected[i, j], 1e-5)
+        gpu[i, j].to_f.should be_close(expected[i, j], 1e-5_f32)
       end
     end
   end
 
   it "applies dropout! on FP32" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    mat = SHAInet::CudaMatrix.new(16, 16, 1.0, precision: SHAInet::Precision::Fp32)
-    mat.dropout!(0.5, 42_u64)
+    mat = SHAInet::CudaMatrix.new(16, 16, 1.0_f32, precision: SHAInet::Precision::Fp32)
+    mat.dropout!(0.5_f32, 42_u64)
     mat.sync_from_device!
     zero_count = 0
     mat.rows.times do |i|
       mat.cols.times do |j|
-        zero_count += 1 if mat[i, j] == 0.0
+        zero_count += 1 if mat[i, j] == 0.0_f32
       end
     end
     zero_count.should be > 0
@@ -33,31 +33,31 @@ describe "CUDA FP32 kernels" do
 
   it "applies sigmoid! on FP32" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    mat = SHAInet::CudaMatrix.new(2, 2, 0.5, precision: SHAInet::Precision::Fp32)
-    expected = SHAInet::SimpleMatrix.new(2, 2, 0.5, precision: SHAInet::Precision::Fp32)
+    mat = SHAInet::CudaMatrix.new(2, 2, 0.5_f32, precision: SHAInet::Precision::Fp32)
+    expected = SHAInet::SimpleMatrix.new(2, 2, 0.5_f32, precision: SHAInet::Precision::Fp32)
     expected.rows.times do |i|
       expected.cols.times do |j|
         v = expected[i, j]
-        expected[i, j] = 1.0 / (1.0 + Math.exp(-v))
+        expected[i, j] = 1.0_f32 / (1.0_f32 + Math.exp(-v))
       end
     end
     mat.sigmoid!
     mat.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        mat[i, j].should be_close(expected[i, j], 1e-5)
+        mat[i, j].should be_close(expected[i, j], 1e-5_f32)
       end
     end
   end
 
   it "applies gelu! on FP32" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    base = SHAInet::SimpleMatrix.from_a([[-1.0, 0.0], [0.5, 2.0]], precision: SHAInet::Precision::Fp32)
+    base = SHAInet::SimpleMatrix.from_a([[-1.0_f32, 0.0_f32], [0.5_f32, 2.0_f32]], precision: SHAInet::Precision::Fp32)
     expected = base.clone
     expected.rows.times do |i|
       expected.cols.times do |j|
         x = expected[i, j]
-        expected[i, j] = 0.5 * x * (1.0 + Math.erf(x / Math.sqrt(2.0)))
+        expected[i, j] = 0.5_f32 * x * (1.0_f32 + Math.erf(x / Math.sqrt(2.0_f32)))
       end
     end
     mat = SHAInet::GPUMemory.to_gpu(base).as(SHAInet::CudaMatrix)
@@ -65,7 +65,7 @@ describe "CUDA FP32 kernels" do
     mat.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        mat[i, j].should be_close(expected[i, j], 1e-5)
+        mat[i, j].should be_close(expected[i, j], 1e-5_f32)
       end
     end
   end

--- a/spec/cuda_fp32_sync_spec.cr
+++ b/spec/cuda_fp32_sync_spec.cr
@@ -3,23 +3,23 @@ require "./spec_helper"
 describe "CudaMatrix FP32 sync" do
   it "syncs data to and from device" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
-    m = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    m[0, 0] = 1.0
-    m[0, 1] = 2.0
-    m[1, 0] = 3.0
-    m[1, 1] = 4.0
+    m = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    m[0, 0] = 1.0_f32
+    m[0, 1] = 2.0_f32
+    m[1, 0] = 3.0_f32
+    m[1, 1] = 4.0_f32
     m.sync_to_device!
     # Corrupt CPU data
     2.times do |i|
       2.times do |j|
-        m.unsafe_set(i, j, 0.0)
+        m.unsafe_set(i, j, 0.0_f32)
       end
     end
     m.mark_device_dirty!
     m.sync_from_device!
-    m[0, 0].should eq(1.0)
-    m[0, 1].should eq(2.0)
-    m[1, 0].should eq(3.0)
-    m[1, 1].should eq(4.0)
+    m[0, 0].should eq(1.0_f32)
+    m[0, 1].should eq(2.0_f32)
+    m[1, 0].should eq(3.0_f32)
+    m[1, 1].should eq(4.0_f32)
   end
 end

--- a/spec/cuda_gemm_fp32_spec.cr
+++ b/spec/cuda_gemm_fp32_spec.cr
@@ -4,51 +4,51 @@ describe "CUDA fp32 GEMM" do
   it "multiplies fp32 matrices" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
 
-    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    c = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    c = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
 
-    a[0, 0] = 1.0
-    a[0, 1] = 2.0
-    a[1, 0] = 3.0
-    a[1, 1] = 4.0
+    a[0, 0] = 1.0_f32
+    a[0, 1] = 2.0_f32
+    a[1, 0] = 3.0_f32
+    a[1, 1] = 4.0_f32
 
-    b[0, 0] = 5.0
-    b[0, 1] = 6.0
-    b[1, 0] = 7.0
-    b[1, 1] = 8.0
+    b[0, 0] = 5.0_f32
+    b[0, 1] = 6.0_f32
+    b[1, 0] = 7.0_f32
+    b[1, 1] = 8.0_f32
 
     c.gemm!(a, b)
     c.sync_from_device!
 
-    c[0, 0].should be_close(19.0, 1e-6)
-    c[0, 1].should be_close(22.0, 1e-6)
-    c[1, 0].should be_close(43.0, 1e-6)
-    c[1, 1].should be_close(50.0, 1e-6)
+    c[0, 0].should be_close(19.0_f32, 1e-6_f32)
+    c[0, 1].should be_close(22.0_f32, 1e-6_f32)
+    c[1, 0].should be_close(43.0_f32, 1e-6_f32)
+    c[1, 1].should be_close(50.0_f32, 1e-6_f32)
   end
 
   it "multiplies fp32 matrices with *" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
 
-    a = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    b = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
+    a = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    b = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
 
-    a[0, 0] = 1.0
-    a[0, 1] = 2.0
-    a[1, 0] = 3.0
-    a[1, 1] = 4.0
+    a[0, 0] = 1.0_f32
+    a[0, 1] = 2.0_f32
+    a[1, 0] = 3.0_f32
+    a[1, 1] = 4.0_f32
 
-    b[0, 0] = 5.0
-    b[0, 1] = 6.0
-    b[1, 0] = 7.0
-    b[1, 1] = 8.0
+    b[0, 0] = 5.0_f32
+    b[0, 1] = 6.0_f32
+    b[1, 0] = 7.0_f32
+    b[1, 1] = 8.0_f32
 
     c = a * b
     c.sync_from_device!
 
-    c[0, 0].should be_close(19.0, 1e-6)
-    c[0, 1].should be_close(22.0, 1e-6)
-    c[1, 0].should be_close(43.0, 1e-6)
-    c[1, 1].should be_close(50.0, 1e-6)
+    c[0, 0].should be_close(19.0_f32, 1e-6_f32)
+    c[0, 1].should be_close(22.0_f32, 1e-6_f32)
+    c[1, 0].should be_close(43.0_f32, 1e-6_f32)
+    c[1, 1].should be_close(50.0_f32, 1e-6_f32)
   end
 end

--- a/spec/cuda_matrix_spec.cr
+++ b/spec/cuda_matrix_spec.cr
@@ -7,14 +7,14 @@ describe SHAInet::CudaMatrix do
     b = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1, 0], [0, 1]]))
 
     sum = a.as(SHAInet::CudaMatrix) + b.as(SHAInet::CudaMatrix)
-    sum[1, 1].should eq(5.0)
+    sum[1, 1].should eq(5.0_f32)
 
     prod = a.as(SHAInet::CudaMatrix) * b.as(SHAInet::CudaMatrix)
-    prod[0, 0].should eq(1.0)
-    prod[1, 1].should eq(4.0)
+    prod[0, 0].should eq(1.0_f32)
+    prod[1, 1].should eq(4.0_f32)
 
     t = a.transpose
-    t[0, 1].should eq(3.0)
+    t[0, 1].should eq(3.0_f32)
   end
 
   it "performs relu and add_bias on GPU when available" do
@@ -29,18 +29,18 @@ describe SHAInet::CudaMatrix do
       matrix.as(SHAInet::CudaMatrix).device_ptr.should_not be_nil
     end
 
-    matrix[0, 0].should eq(0.0 + 1.0)
-    matrix[0, 1].should eq(2.0 + 1.0)
-    matrix[1, 0].should eq(0.0 + 1.0)
-    matrix[1, 1].should eq(4.0 + 1.0)
+    matrix[0, 0].should eq(0.0_f32 + 1.0_f32)
+    matrix[0, 1].should eq(2.0_f32 + 1.0_f32)
+    matrix[1, 0].should eq(0.0_f32 + 1.0_f32)
+    matrix[1, 1].should eq(4.0_f32 + 1.0_f32)
   end
 
   it "raises error for non-Fp32 precision when cuDNN is unavailable" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
     pending! "cuDNN available" if SHAInet::CUDNN.available?
 
-    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    bias = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp32)
+    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    bias = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp32)
 
     expect_raises(Exception, /non-FP32 precisions require cuDNN/) do
       matrix.add_bias!(bias)
@@ -49,7 +49,7 @@ describe SHAInet::CudaMatrix do
 
   it "checks precision support for transpose" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
-    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp16)
+    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp16)
 
     if SHAInet::CUDA.kernels_available?
       matrix.transpose.should be_a(SHAInet::CudaMatrix)

--- a/spec/cuda_mul_row_vector_spec.cr
+++ b/spec/cuda_mul_row_vector_spec.cr
@@ -7,10 +7,10 @@ describe "CudaMatrix mul_row_vector!" do
     v = SHAInet::CudaMatrix.from_a([[2.0_f32, 3.0_f32]], SHAInet::Precision::Fp16)
     a.mul_row_vector!(v)
     a.sync_from_device!
-    a[0, 0].should be_close(2.0, 0.01)
-    a[0, 1].should be_close(6.0, 0.01)
-    a[1, 0].should be_close(6.0, 0.01)
-    a[1, 1].should be_close(12.0, 0.01)
+    a[0, 0].should be_close(2.0_f32, 0.01_f32)
+    a[0, 1].should be_close(6.0_f32, 0.01_f32)
+    a[1, 0].should be_close(6.0_f32, 0.01_f32)
+    a[1, 1].should be_close(12.0_f32, 0.01_f32)
   end
 
   it "multiplies columns for Fp32 precision" do
@@ -19,9 +19,9 @@ describe "CudaMatrix mul_row_vector!" do
     v = SHAInet::CudaMatrix.from_a([[0.5_f32, 1.5_f32]], SHAInet::Precision::Fp32)
     a.mul_row_vector!(v)
     a.sync_from_device!
-    a[0, 0].should be_close(0.5, 1e-6)
-    a[0, 1].should be_close(3.0, 1e-6)
-    a[1, 0].should be_close(1.5, 1e-6)
-    a[1, 1].should be_close(6.0, 1e-6)
+    a[0, 0].should be_close(0.5_f32, 1e-6_f32)
+    a[0, 1].should be_close(3.0_f32, 1e-6_f32)
+    a[1, 0].should be_close(1.5_f32, 1e-6_f32)
+    a[1, 1].should be_close(6.0_f32, 1e-6_f32)
   end
 end

--- a/spec/cuda_set_row_spec.cr
+++ b/spec/cuda_set_row_spec.cr
@@ -5,20 +5,20 @@ describe "CudaMatrix#set_row!" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
 
     src = SHAInet::CudaMatrix.from_a([
-      [1.0, 2.0, 3.0],
-      [4.0, 5.0, 6.0],
+      [1.0_f32, 2.0_f32, 3.0_f32],
+      [4.0_f32, 5.0_f32, 6.0_f32],
     ], SHAInet::Precision::Fp32)
 
     dst = SHAInet::CudaMatrix.from_a([
-      [0.0, 0.0, 0.0],
-      [0.0, 0.0, 0.0],
+      [0.0_f32, 0.0_f32, 0.0_f32],
+      [0.0_f32, 0.0_f32, 0.0_f32],
     ], SHAInet::Precision::Fp32)
 
     dst.set_row!(1, src, 0)
     dst.sync_from_device!
 
     3.times do |j|
-      dst[1, j].should be_close(src[0, j], 1e-6)
+      dst[1, j].should be_close(src[0, j], 1e-6_f32)
     end
   end
 
@@ -26,20 +26,20 @@ describe "CudaMatrix#set_row!" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
 
     src = SHAInet::CudaMatrix.from_a([
-      [1.0, 2.0, 3.0],
-      [4.0, 5.0, 6.0],
+      [1.0_f32, 2.0_f32, 3.0_f32],
+      [4.0_f32, 5.0_f32, 6.0_f32],
     ], SHAInet::Precision::Fp16)
 
     dst = SHAInet::CudaMatrix.from_a([
-      [0.0, 0.0, 0.0],
-      [0.0, 0.0, 0.0],
+      [0.0_f32, 0.0_f32, 0.0_f32],
+      [0.0_f32, 0.0_f32, 0.0_f32],
     ], SHAInet::Precision::Fp16)
 
     dst.set_row!(1, src, 0)
     dst.sync_from_device!
 
     3.times do |j|
-      dst[1, j].should be_close(src[0, j], 1e-2)
+      dst[1, j].should be_close(src[0, j], 1e-2_f32)
     end
   end
 end

--- a/spec/cuda_softmax_dropout_spec.cr
+++ b/spec/cuda_softmax_dropout_spec.cr
@@ -3,14 +3,14 @@ require "./spec_helper"
 describe "CUDA softmax and dropout" do
   it "matches CPU softmax" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    cpu = SHAInet::SimpleMatrix.from_a([[1.0, 2.0], [3.0, 4.0]])
+    cpu = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32], [3.0_f32, 4.0_f32]])
     gpu = SHAInet::CudaMatrix.from_a(cpu.to_a, SHAInet::Precision::Fp16)
     gpu_out = SHAInet.softmax_rows(gpu)
     gpu_out.sync_from_device! if gpu_out.is_a?(SHAInet::CudaMatrix)
     cpu_out = SHAInet.softmax_rows(cpu)
     cpu_out.rows.times do |i|
       cpu_out.cols.times do |j|
-        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6)
+        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6_f32)
       end
     end
   end
@@ -19,7 +19,7 @@ describe "CUDA softmax and dropout" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
     mat = SHAInet::CudaMatrix.ones(10, 10, SHAInet::Precision::Fp16)
     runs = 200
-    total_ratio = 0.0
+    total_ratio = 0.0_f32
     runs.times do |run_idx|
       out = SHAInet::TransformerDropout.apply(mat, 30)
       out.sync_from_device! if out.is_a?(SHAInet::CudaMatrix)
@@ -27,12 +27,12 @@ describe "CUDA softmax and dropout" do
       dropped = 0
       mat.rows.times do |i|
         mat.cols.times do |j|
-          dropped += 1 if out[i, j] == 0.0
+          dropped += 1 if out[i, j] == 0.0_f32
         end
       end
       total_ratio += dropped.to_f / (mat.rows * mat.cols)
     end
     average = total_ratio / runs
-    (average).should be_close(0.30, 0.05)
+    (average).should be_close(0.30_f32, 0.05_f32)
   end
 end

--- a/spec/cuda_softmax_inplace_spec.cr
+++ b/spec/cuda_softmax_inplace_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe "CudaMatrix#softmax_rows!" do
   it "matches CPU softmax" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    cpu = SHAInet::SimpleMatrix.from_a([[0.5, 1.5, 2.5], [3.0, 0.0, -1.0]])
+    cpu = SHAInet::SimpleMatrix.from_a([[0.5_f32, 1.5_f32, 2.5_f32], [3.0_f32, 0.0_f32, -1.0_f32]])
     expected = SHAInet.softmax_rows(cpu)
 
     gpu = SHAInet::GPUMemory.to_gpu(cpu).as(SHAInet::CudaMatrix)
@@ -12,7 +12,7 @@ describe "CudaMatrix#softmax_rows!" do
 
     expected.rows.times do |i|
       expected.cols.times do |j|
-        gpu[i, j].should be_close(expected[i, j], 1e-6)
+        gpu[i, j].should be_close(expected[i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/cudnn_add_bias_spec.cr
+++ b/spec/cudnn_add_bias_spec.cr
@@ -4,8 +4,8 @@ describe "CUDNN.add_bias!" do
   it "raises on precision mismatch" do
     pending! "cuDNN not available" unless SHAInet::CUDA.cudnn_available?
 
-    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0, SHAInet::Precision::Fp32)
-    bias = SHAInet::CudaMatrix.new(1, 2, 0.0, SHAInet::Precision::Fp16)
+    matrix = SHAInet::CudaMatrix.new(2, 2, 0.0_f32, SHAInet::Precision::Fp32)
+    bias = SHAInet::CudaMatrix.new(1, 2, 0.0_f32, SHAInet::Precision::Fp16)
 
     expect_raises(ArgumentError, /matrix precision.*bias precision/) do
       SHAInet::CUDNN.add_bias!(matrix, bias)

--- a/spec/cudnn_descriptor_spec.cr
+++ b/spec/cudnn_descriptor_spec.cr
@@ -6,18 +6,18 @@ describe "cuDNN descriptor" do
   it "performs an activation without errors" do
     pending! "cuDNN not available" unless SHAInet::CUDA.cudnn_available?
 
-    input = SHAInet::CudaMatrix.new(2, 3, 1.0)
-    output = SHAInet::CudaMatrix.new(2, 3, 0.0)
+    input = SHAInet::CudaMatrix.new(2, 3, 1.0_f32)
+    output = SHAInet::CudaMatrix.new(2, 3, 0.0_f32)
 
     # Uses create_tensor_descriptor_2d internally
     SHAInet::CUDNN.sigmoid_forward!(output, input)
 
     output.sync_from_device!
-    expected = 1.0 / (1.0 + Math.exp(-1.0))
+    expected = 1.0_f32 / (1.0_f32 + Math.exp(-1.0_f32))
 
     output.rows.times do |i|
       output.cols.times do |j|
-        output[i, j].should be_close(expected, 1e-6)
+        output[i, j].should be_close(expected, 1e-6_f32)
       end
     end
   end

--- a/spec/data_parallel_trainer_spec.cr
+++ b/spec/data_parallel_trainer_spec.cr
@@ -7,10 +7,10 @@ describe "Data parallel trainer" do
     pending! "multi-gpu tests disabled" unless ENV["MULTI_GPU_TEST"]?
 
     data = [
-      [[0.0, 0.0], [0.0]],
-      [[0.0, 1.0], [1.0]],
-      [[1.0, 0.0], [1.0]],
-      [[1.0, 1.0], [0.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[0.0_f32, 1.0_f32], [1.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
+      [[1.0_f32, 1.0_f32], [0.0_f32]],
     ]
 
     net1 = SHAInet::Network.new
@@ -19,7 +19,7 @@ describe "Data parallel trainer" do
     net1.add_layer(:output, 1)
     net1.fully_connect
     net1.train(data: data, training_type: :sgd, cost_function: :mse, epochs: 2, mini_batch_size: 2, log_each: 10)
-    res1 = net1.run([0.0, 1.0])[0]
+    res1 = net1.run([0.0_f32, 1.0_f32])[0]
 
     net2 = SHAInet::Network.new
     net2.add_layer(:input, 2)
@@ -27,8 +27,8 @@ describe "Data parallel trainer" do
     net2.add_layer(:output, 1)
     net2.fully_connect
     net2.train(data: data, training_type: :sgd, cost_function: :mse, epochs: 2, mini_batch_size: 2, log_each: 10, training_mode: :data_parallel, devices: [0, 1])
-    res2 = net2.run([0.0, 1.0])[0]
+    res2 = net2.run([0.0_f32, 1.0_f32])[0]
 
-    (res1 - res2).abs.should be < 1e-5
+    (res1 - res2).abs.should be < 1e-5_f32
   end
 end

--- a/spec/data_spec.cr
+++ b/spec/data_spec.cr
@@ -14,7 +14,7 @@ describe SHAInet::Data do
   it "can be split into a test set and a training set according to a given fraction" do
     puts "\n"
     data = SHAInet::Data.new_with_csv_input_target(iris, 0..3, 4)
-    training_set, test_set = data.split(0.67)
+    training_set, test_set = data.split(0.67_f32)
     training_set.should be_a(SHAInet::TrainingData)
     test_set.should be_a(SHAInet::TestData)
     training_set.data.size.should eq(100)
@@ -32,73 +32,73 @@ describe SHAInet::Data do
   it "should normalize inputs" do
     puts "\n"
     inputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
     outputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
 
     data = SHAInet::Data.new(inputs, outputs)
     data.normalize_min_max
-    data.normalize_inputs([1]).should eq([0.0])
-    data.normalize_inputs([2]).should eq([0.5])
-    data.normalize_inputs([3]).should eq([1.0])
+    data.normalize_inputs([1]).should eq([0.0_f32])
+    data.normalize_inputs([2]).should eq([0.5_f32])
+    data.normalize_inputs([3]).should eq([1.0_f32])
   end
 
   puts "############################################################"
   it "should normalize outputs" do
     puts "\n"
     inputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
     outputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
 
     data = SHAInet::Data.new(inputs, outputs)
     data.normalize_min_max
-    data.normalize_outputs([1]).should eq([0.0])
-    data.normalize_outputs([2]).should eq([0.5])
-    data.normalize_outputs([3]).should eq([1.0])
+    data.normalize_outputs([1]).should eq([0.0_f32])
+    data.normalize_outputs([2]).should eq([0.5_f32])
+    data.normalize_outputs([3]).should eq([1.0_f32])
   end
 
   puts "############################################################"
   it "should denormalize outputs" do
     puts "\n"
     inputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
     outputs = [
-      [1.0], [2.0], [3.0],
+      [1.0_f32], [2.0_f32], [3.0_f32],
     ]
 
     data = SHAInet::Data.new(inputs, outputs)
     data.normalize_min_max
-    data.denormalize_outputs([0.0]).should eq([1.0])
-    data.denormalize_outputs([0.5]).should eq([2.0])
-    data.denormalize_outputs([1.0]).should eq([3.0])
+    data.denormalize_outputs([0.0_f32]).should eq([1.0_f32])
+    data.denormalize_outputs([0.5_f32]).should eq([2.0_f32])
+    data.denormalize_outputs([1.0_f32]).should eq([3.0_f32])
   end
 
   puts "############################################################"
   it "should handle constant input columns" do
     puts "\n"
     inputs = [
-      [1.0, 5.0],
-      [2.0, 5.0],
-      [3.0, 5.0],
+      [1.0_f32, 5.0_f32],
+      [2.0_f32, 5.0_f32],
+      [3.0_f32, 5.0_f32],
     ]
     outputs = [
-      [1.0],
-      [2.0],
-      [3.0],
+      [1.0_f32],
+      [2.0_f32],
+      [3.0_f32],
     ]
 
     data = SHAInet::Data.new(inputs, outputs)
     data.normalize_min_max
     data.normalized_inputs.should eq([
-      [0.0, 1.0],
-      [0.5, 1.0],
-      [1.0, 1.0],
+      [0.0_f32, 1.0_f32],
+      [0.5_f32, 1.0_f32],
+      [1.0_f32, 1.0_f32],
     ])
   end
 end

--- a/spec/decoding_spec.cr
+++ b/spec/decoding_spec.cr
@@ -13,6 +13,6 @@ describe SHAInet do
     rng = Random::DEFAULT
     rng.new_seed(1_u64, 1_u64)
     logits = [0.5_f32, 0.3_f32, 0.1_f32, 0.1_f32]
-    SHAInet.top_p_sample(logits, 0.6, rng: rng).should eq(0)
+    SHAInet.top_p_sample(logits, 0.6_f32, rng: rng).should eq(0)
   end
 end

--- a/spec/embedding_cuda_lookup_spec.cr
+++ b/spec/embedding_cuda_lookup_spec.cr
@@ -7,7 +7,7 @@ describe "Embedding GPU lookup" do
     # Create a simple embedding layer with fixed values
     layer = SHAInet::EmbeddingLayer.new(5, 4)
     if layer.embeddings.is_a?(SHAInet::CudaMatrix)
-      fp16 = SHAInet::CudaMatrix.new(5, 4, 0.0, SHAInet::Precision::Fp16)
+      fp16 = SHAInet::CudaMatrix.new(5, 4, 0.0_f32, SHAInet::Precision::Fp16)
       5.times do |r|
         4.times do |c|
           fp16[r, c] = layer.embeddings[r, c]
@@ -19,7 +19,7 @@ describe "Embedding GPU lookup" do
 
     # Set the embedding values
     token_id = 1
-    expected_values = [0.1, 0.2, 0.3, 0.4]
+    expected_values = [0.1_f32, 0.2_f32, 0.3_f32, 0.4_f32]
 
     # Set the values directly in the embeddings matrix
     expected_values.each_with_index do |val, idx|
@@ -37,7 +37,7 @@ describe "Embedding GPU lookup" do
     # Compare results
     result.size.should eq(expected_values.size)
     result.each_with_index do |val, idx|
-      val.should be_close(expected_values[idx], 1e-6)
+      val.should be_close(expected_values[idx], 1e-6_f32)
     end
   end
 end

--- a/spec/embedding_cuda_parity_spec.cr
+++ b/spec/embedding_cuda_parity_spec.cr
@@ -7,33 +7,33 @@ describe "Embedding GPU parity" do
     # Create embedding layers with fixed values
     vocab_size = 3
     embed_size = 2
-    lr = 0.1
+    lr = 0.1_f32
 
     # First with GPU disabled
     ENV["SHAINET_DISABLE_CUDA"] = "1"
     cpu_layer = SHAInet::EmbeddingLayer.new(vocab_size, embed_size)
 
-    # Set all embeddings to 0.5
+    # Set all embeddings to 0.5_f32
     vocab_size.times do |r|
       embed_size.times do |c|
-        cpu_layer.embeddings[r, c] = 0.5
+        cpu_layer.embeddings[r, c] = 0.5_f32
       end
     end
 
     # Apply gradients
     cpu_layer.embed(1)
-    cpu_layer.gradients[1, 0] = 0.2
-    cpu_layer.gradients[1, 1] = 0.2
-    cpu_layer.apply_gradients(lr, 0.0)
+    cpu_layer.gradients[1, 0] = 0.2_f32
+    cpu_layer.gradients[1, 1] = 0.2_f32
+    cpu_layer.apply_gradients(lr, 0.0_f32)
 
     # Now with GPU
     ENV.delete("SHAINET_DISABLE_CUDA")
     gpu_layer = SHAInet::EmbeddingLayer.new(vocab_size, embed_size)
 
-    # Set all embeddings to 0.5
+    # Set all embeddings to 0.5_f32
     vocab_size.times do |r|
       embed_size.times do |c|
-        gpu_layer.embeddings[r, c] = 0.5
+        gpu_layer.embeddings[r, c] = 0.5_f32
       end
     end
 
@@ -44,20 +44,20 @@ describe "Embedding GPU parity" do
 
     # Apply gradients
     gpu_layer.embed(1)
-    gpu_layer.gradients[1, 0] = 0.2
-    gpu_layer.gradients[1, 1] = 0.2
+    gpu_layer.gradients[1, 0] = 0.2_f32
+    gpu_layer.gradients[1, 1] = 0.2_f32
     # Make sure gradients are synced to device
     if gpu_layer.gradients.is_a?(SHAInet::CudaMatrix)
       gpu_layer.gradients.as(SHAInet::CudaMatrix).sync_to_device!
     end
-    gpu_layer.apply_gradients(lr, 0.0)
+    gpu_layer.apply_gradients(lr, 0.0_f32)
 
     # Check results for updated values
     vocab_size.times do |r|
       embed_size.times do |c|
         gpu_val = gpu_layer.embeddings[r, c]
         cpu_val = cpu_layer.embeddings[r, c]
-        gpu_val.should be_close(cpu_val, 1e-6)
+        gpu_val.should be_close(cpu_val, 1e-6_f32)
       end
     end
   end

--- a/spec/embedding_layer_spec.cr
+++ b/spec/embedding_layer_spec.cr
@@ -15,8 +15,8 @@ describe SHAInet::EmbeddingLayer do
     layer = SHAInet::EmbeddingLayer.new(3, 2)
 
     # Set some specific values for testing
-    layer.embeddings[1, 0] = 0.5
-    layer.embeddings[1, 1] = 0.5
+    layer.embeddings[1, 0] = 0.5_f32
+    layer.embeddings[1, 1] = 0.5_f32
 
     before = layer.lookup(1)
     puts "Before: #{before.inspect}, embeddings at 1: #{layer.embeddings[1, 0]}, #{layer.embeddings[1, 1]}"
@@ -25,11 +25,11 @@ describe SHAInet::EmbeddingLayer do
     layer.embed(1)
 
     # Set gradients directly
-    layer.gradients[1, 0] = 0.1
-    layer.gradients[1, 1] = 0.1
+    layer.gradients[1, 0] = 0.1_f32
+    layer.gradients[1, 1] = 0.1_f32
 
     # Apply gradients with a learning rate
-    layer.apply_gradients(0.1, 0.0)
+    layer.apply_gradients(0.1_f32, 0.0_f32)
 
     after = layer.lookup(1)
     puts "After: #{after.inspect}, embeddings at 1: #{layer.embeddings[1, 0]}, #{layer.embeddings[1, 1]}"

--- a/spec/exit_save_spec.cr
+++ b/spec/exit_save_spec.cr
@@ -16,7 +16,7 @@ describe SHAInet::Network do
       net.fully_connect
       net.enable_exit_save(path)
       Process.signal(Signal::INT, Process.pid)
-      sleep 0.1
+      sleep 0.1_f32
     end
 
     proc.wait

--- a/spec/functions_spec.cr
+++ b/spec/functions_spec.cr
@@ -4,44 +4,44 @@ describe SHAInet do
   puts "############################################################"
   it "check sigmoid" do
     puts "\n"
-    ((0..1).includes?(SHAInet.sigmoid.call(0.5).first)).should eq(true)
+    ((0..1).includes?(SHAInet.sigmoid.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   it "check bp_sigmoid" do
     puts "\n"
-    ((-1..1).includes?(SHAInet.bp_sigmoid.call(0.5).first)).should eq(true)
+    ((-1..1).includes?(SHAInet.bp_sigmoid.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   it "check log_sigmoid" do
     puts "\n"
-    ((0..1).includes?(SHAInet.log_sigmoid.call(0.5).first)).should eq(true)
+    ((0..1).includes?(SHAInet.log_sigmoid.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   it "check tanh" do
     puts "\n"
-    ((-1..1).includes?(SHAInet.tanh.call(0.5).first)).should eq(true)
+    ((-1..1).includes?(SHAInet.tanh.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   it "check relu" do
     puts "\n"
-    ((0..Int64::MAX).includes?(SHAInet.relu.call(0.5).first)).should eq(true)
+    ((0..Int64::MAX).includes?(SHAInet.relu.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   it "check l_relu" do
     puts "\n"
-    ((Int64::MIN..Int64::MAX).includes?(SHAInet.l_relu.call(0.5).first)).should eq(true)
+    ((Int64::MIN..Int64::MAX).includes?(SHAInet.l_relu.call(0.5_f32).first)).should eq(true)
   end
 
   puts "############################################################"
   # it "check cross entropy" do
   puts "\n"
 
-  #   puts SHAInet.cross_entropy_cost(0.0, 1.0)
+  #   puts SHAInet.cross_entropy_cost(0.0_f32, 1.0_f32)
   # end
 
   puts "############################################################"

--- a/spec/gelu_precision_spec.cr
+++ b/spec/gelu_precision_spec.cr
@@ -3,12 +3,12 @@ require "./spec_helper"
 describe "CUDA GELU precision fallbacks" do
   it "applies gelu! on FP16" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
-    base = SHAInet::SimpleMatrix.from_a([[-1.0, 0.0], [0.5, 2.0]], precision: SHAInet::Precision::Fp16)
+    base = SHAInet::SimpleMatrix.from_a([[-1.0_f32, 0.0_f32], [0.5_f32, 2.0_f32]], precision: SHAInet::Precision::Fp16)
     expected = base.clone
     expected.rows.times do |i|
       expected.cols.times do |j|
         x = expected[i, j]
-        expected[i, j] = 0.5 * x * (1.0 + Math.erf(x / Math.sqrt(2.0)))
+        expected[i, j] = 0.5_f32 * x * (1.0_f32 + Math.erf(x / Math.sqrt(2.0_f32)))
       end
     end
     mat = SHAInet::GPUMemory.to_gpu(base).as(SHAInet::CudaMatrix)
@@ -16,19 +16,19 @@ describe "CUDA GELU precision fallbacks" do
     mat.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        mat[i, j].should be_close(expected[i, j], 1e-2)
+        mat[i, j].should be_close(expected[i, j], 1e-2_f32)
       end
     end
   end
 
   it "applies gelu! on BF16" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
-    base = SHAInet::SimpleMatrix.from_a([[-1.0, 0.0], [0.5, 2.0]], precision: SHAInet::Precision::Bf16)
+    base = SHAInet::SimpleMatrix.from_a([[-1.0_f32, 0.0_f32], [0.5_f32, 2.0_f32]], precision: SHAInet::Precision::Bf16)
     expected = base.clone
     expected.rows.times do |i|
       expected.cols.times do |j|
         x = expected[i, j]
-        expected[i, j] = 0.5 * x * (1.0 + Math.erf(x / Math.sqrt(2.0)))
+        expected[i, j] = 0.5_f32 * x * (1.0_f32 + Math.erf(x / Math.sqrt(2.0_f32)))
       end
     end
     mat = SHAInet::GPUMemory.to_gpu(base).as(SHAInet::CudaMatrix)
@@ -36,7 +36,7 @@ describe "CUDA GELU precision fallbacks" do
     mat.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        mat[i, j].should be_close(expected[i, j], 1e-2)
+        mat[i, j].should be_close(expected[i, j], 1e-2_f32)
       end
     end
   end

--- a/spec/gelu_spec.cr
+++ b/spec/gelu_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe "GELU activation" do
   it "applies gelu! on SimpleMatrix" do
-    mat = SHAInet::SimpleMatrix.from_a([[-1.0, 0.0, 1.0], [0.5, -0.5, 2.0]])
+    mat = SHAInet::SimpleMatrix.from_a([[-1.0_f32, 0.0_f32, 1.0_f32], [0.5_f32, -0.5_f32, 2.0_f32]])
     expected = mat.clone
     expected.rows.times do |i|
       expected.cols.times do |j|
@@ -12,14 +12,14 @@ describe "GELU activation" do
     mat.gelu!
     mat.rows.times do |i|
       mat.cols.times do |j|
-        mat[i, j].should be_close(expected[i, j], 1e-6)
+        mat[i, j].should be_close(expected[i, j], 1e-6_f32)
       end
     end
   end
 
   it "applies gelu! on CudaMatrix" do
     pending! "CUDA not available" unless SHAInet::CUDA.fully_available?
-    base = SHAInet::SimpleMatrix.from_a([[-1.0, 0.0, 1.0], [0.5, -0.5, 2.0]])
+    base = SHAInet::SimpleMatrix.from_a([[-1.0_f32, 0.0_f32, 1.0_f32], [0.5_f32, -0.5_f32, 2.0_f32]])
     expected = base.clone
     expected.rows.times do |i|
       expected.cols.times do |j|
@@ -33,18 +33,18 @@ describe "GELU activation" do
     mat_out.sync_from_device!
     expected.rows.times do |i|
       expected.cols.times do |j|
-        mat_out[i, j].should be_close(expected[i, j], 1e-6)
+        mat_out[i, j].should be_close(expected[i, j], 1e-6_f32)
       end
     end
   end
 
   it "matches numerical derivative" do
-    x = 0.5
-    eps = 1e-6
+    x = 0.5_f32
+    eps = 1e-6_f32
     forward = SHAInet._gelu(x + eps)
     backward = SHAInet._gelu(x - eps)
     numeric = (forward - backward) / (2 * eps)
     formula = SHAInet._gelu_prime(x)
-    formula.should be_close(numeric, 1e-6)
+    formula.should be_close(numeric, 1e-6_f32)
   end
 end

--- a/spec/gpu_memory_fp16_copy_spec.cr
+++ b/spec/gpu_memory_fp16_copy_spec.cr
@@ -3,13 +3,13 @@ require "./spec_helper"
 describe "GPUMemory FP16 copies" do
   it "copies SimpleMatrix to GPU" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
-    src = SHAInet::SimpleMatrix.from_a([[1.0, 2.0], [3.0, 4.0]], SHAInet::Precision::Fp16)
+    src = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32], [3.0_f32, 4.0_f32]], SHAInet::Precision::Fp16)
     dest = SHAInet::CudaMatrix.new(2, 2, precision: SHAInet::Precision::Fp16)
     SHAInet::GPUMemory.to_gpu!(src, dest)
     dest.sync_from_device!
     2.times do |i|
       2.times do |j|
-        dest[i, j].should be_close(src[i, j], 1e-2)
+        dest[i, j].should be_close(src[i, j], 1e-2_f32)
       end
     end
   end
@@ -17,11 +17,11 @@ describe "GPUMemory FP16 copies" do
   it "copies FP16 array to GPU" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
     dest = SHAInet::CudaMatrix.new(1, 4, precision: SHAInet::Precision::Fp16)
-    arr = [1.0, 2.0, 3.0, 4.0]
+    arr = [1.0_f32, 2.0_f32, 3.0_f32, 4.0_f32]
     SHAInet::GPUMemory.to_gpu!(arr, dest)
     dest.sync_from_device!
     4.times do |i|
-      dest[0, i].should be_close(arr[i], 1e-2)
+      dest[0, i].should be_close(arr[i], 1e-2_f32)
     end
   end
 end

--- a/spec/gpu_precision_training_spec.cr
+++ b/spec/gpu_precision_training_spec.cr
@@ -4,8 +4,8 @@ describe "GPU precision training" do
   it "trains a tiny fp16 network" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
 
-    inputs = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
-    outputs = [[0.0], [1.0], [1.0], [0.0]]
+    inputs = [[0.0_f32, 0.0_f32], [0.0_f32, 1.0_f32], [1.0_f32, 0.0_f32], [1.0_f32, 1.0_f32]]
+    outputs = [[0.0_f32], [1.0_f32], [1.0_f32], [0.0_f32]]
 
     data = SHAInet::TrainingData.new(inputs, outputs, preload_gpu: true)
     data.normalize_min_max
@@ -35,7 +35,7 @@ describe "GPU precision training" do
     output.precision.should eq(net.precision)
 
     after_w = net.output_layers.last.weights[0, 0]
-    (after_w - before_w).abs.should be > 0.0
+    (after_w - before_w).abs.should be > 0.0_f32
 
     result = net.run(input)
     result.should be_a(SHAInet::CudaMatrix)
@@ -45,8 +45,8 @@ describe "GPU precision training" do
   it "trains a tiny fp32 network" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
 
-    inputs = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
-    outputs = [[0.0], [1.0], [1.0], [0.0]]
+    inputs = [[0.0_f32, 0.0_f32], [0.0_f32, 1.0_f32], [1.0_f32, 0.0_f32], [1.0_f32, 1.0_f32]]
+    outputs = [[0.0_f32], [1.0_f32], [1.0_f32], [0.0_f32]]
 
     data = SHAInet::TrainingData.new(inputs, outputs, preload_gpu: true)
     data.normalize_min_max
@@ -76,7 +76,7 @@ describe "GPU precision training" do
     output.precision.should eq(net.precision)
 
     after_w = net.output_layers.last.weights[0, 0]
-    (after_w - before_w).abs.should be > 0.0
+    (after_w - before_w).abs.should be > 0.0_f32
 
     result = net.run(input)
     result.should be_a(SHAInet::CudaMatrix)

--- a/spec/int8_quantization_spec.cr
+++ b/spec/int8_quantization_spec.cr
@@ -11,16 +11,16 @@ describe "INT8 quantization" do
     net.fully_connect
 
     layer = net.output_layers.last
-    layer.weights[0, 0] = -0.05
-    layer.weights[1, 0] = 0.05
-    layer.biases[0, 0] = 0.0
+    layer.weights[0, 0] = -0.05_f32
+    layer.weights[1, 0] = 0.05_f32
+    layer.biases[0, 0] = 0.0_f32
 
-    out_fp = net.run([0.5, -0.5])
+    out_fp = net.run([0.5_f32, -0.5_f32])
 
     net.quantize_int8!
     net.precision = SHAInet::Precision::Int8
-    out_int8 = net.run([0.5, -0.5])
+    out_int8 = net.run([0.5_f32, -0.5_f32])
 
-    out_int8.first.should be_close(out_fp.first, 2e-2)
+    out_int8.first.should be_close(out_fp.first, 2e-2_f32)
   end
 end

--- a/spec/integration_spec.cr
+++ b/spec/integration_spec.cr
@@ -11,7 +11,7 @@ describe SHAInet::Network do
     data = SHAInet::Data.new_with_csv_input_target(__DIR__ + "/test_data/iris.csv", 0..3, 4)
 
     # Split the data in a training set and a test set
-    training_set, test_set = data.split(0.67)
+    training_set, test_set = data.split(0.67_f32)
 
     # Initiate a new network
     iris = SHAInet::Network.new
@@ -28,7 +28,7 @@ describe SHAInet::Network do
       training_type: :adam,
       cost_function: :mse,
       epochs: 100,
-      error_threshold: 1e-9,
+      error_threshold: 1e-9_f32,
       mini_batch_size: 4,
       log_each: 20,
       show_slice: false)
@@ -39,7 +39,7 @@ describe SHAInet::Network do
 
     # With only 100 epochs, we just want to see that some learning happened
     # and that training is fast (not hours like before)
-    accuracy.should be > 0.2 # Very basic expectation - just that it's better than random
+    accuracy.should be > 0.2_f32 # Very basic expectation - just that it's better than random
 
     puts "✓ Training completed quickly and MSE decreased successfully"
   end

--- a/spec/label_gpu_transfer_spec.cr
+++ b/spec/label_gpu_transfer_spec.cr
@@ -7,8 +7,8 @@ describe "softmax_cross_entropy_label_loss_and_gradient" do
     cols = 3
     pred = SHAInet::CudaMatrix.new(rows, cols).random_fill!
     labels = SHAInet::CudaMatrix.new(rows, 1)
-    labels[0, 0] = 1.0
-    labels[1, 0] = 0.0
+    labels[0, 0] = 1.0_f32
+    labels[1, 0] = 0.0_f32
     labels.sync_to_device!
     pred.sync_to_device!
     grad = SHAInet::CudaMatrix.new(rows, cols)
@@ -17,7 +17,7 @@ describe "softmax_cross_entropy_label_loss_and_gradient" do
     labels.mark_device_dirty!
     grad.mark_device_dirty!
     SHAInet::CudaMatrix.reset_sync_stats
-    loss = 0.0
+    loss = 0.0_f32
     SHAInet::CUDNN.softmax_cross_entropy_label_loss_and_gradient(pred, labels, pointerof(loss), grad)
     stats = SHAInet::CudaMatrix.sync_stats
     stats[:sync_from_device_count].should eq(0_u64)

--- a/spec/layer_norm_cuda_parity_spec.cr
+++ b/spec/layer_norm_cuda_parity_spec.cr
@@ -39,14 +39,14 @@ describe "LayerNorm GPU parity" do
 
       rows.times do |i|
         cols.times do |j|
-          out_gpu[i, j].should be_close(out_cpu[i, j], 1e-6)
-          dx_gpu[i, j].should be_close(dx_cpu[i, j], 1e-6)
+          out_gpu[i, j].should be_close(out_cpu[i, j], 1e-6_f32)
+          dx_gpu[i, j].should be_close(dx_cpu[i, j], 1e-6_f32)
         end
       end
 
       cols.times do |j|
-        gpu_ln.g_gamma[0, j].should be_close(g_gamma_cpu[0, j], 1e-6)
-        gpu_ln.g_beta[0, j].should be_close(g_beta_cpu[0, j], 1e-6)
+        gpu_ln.g_gamma[0, j].should be_close(g_gamma_cpu[0, j], 1e-6_f32)
+        gpu_ln.g_beta[0, j].should be_close(g_beta_cpu[0, j], 1e-6_f32)
       end
     end
   end

--- a/spec/lr_scheduler_spec.cr
+++ b/spec/lr_scheduler_spec.cr
@@ -9,10 +9,10 @@ describe "Learning rate scheduler" do
     net.learning_rate = 1.0_f32
     net.warmup_steps = 2
     net.decay_type = :step
-    net.decay_rate = 0.5
+    net.decay_rate = 0.5_f32
     net.decay_step = 2
 
-    data = [[[0.0], [0.0]]]
+    data = [[[0.0_f32], [0.0_f32]]]
 
     net.train(
       data: data,
@@ -21,11 +21,11 @@ describe "Learning rate scheduler" do
       epochs: 3,
       mini_batch_size: 1,
       log_each: 10,
-      error_threshold: 0.0
+      error_threshold: 0.0_f32
     )
 
     net.time_step.should eq(3)
-    net.current_learning_rate.should be_close(1.0, 1e-6)
+    net.current_learning_rate.should be_close(1.0_f32, 1e-6_f32)
 
     net.train(
       data: data,
@@ -34,10 +34,10 @@ describe "Learning rate scheduler" do
       epochs: 2,
       mini_batch_size: 1,
       log_each: 10,
-      error_threshold: 0.0
+      error_threshold: 0.0_f32
     )
 
     net.time_step.should eq(5)
-    net.current_learning_rate.should be_close(0.5, 1e-6)
+    net.current_learning_rate.should be_close(0.5_f32, 1e-6_f32)
   end
 end

--- a/spec/matrix_autograd_spec.cr
+++ b/spec/matrix_autograd_spec.cr
@@ -3,19 +3,19 @@ require "./spec_helper"
 describe SHAInet::SimpleMatrix do
   it "propagates gradients through matrix operations" do
     a = SHAInet::SimpleMatrix.tensor(1, 2)
-    a[0, 0] = SHAInet::Autograd::Tensor.new(2.0)
-    a[0, 1] = SHAInet::Autograd::Tensor.new(3.0)
+    a[0, 0] = SHAInet::Autograd::Tensor.new(2.0_f32)
+    a[0, 1] = SHAInet::Autograd::Tensor.new(3.0_f32)
 
     b = SHAInet::SimpleMatrix.tensor(2, 1)
-    b[0, 0] = SHAInet::Autograd::Tensor.new(4.0)
-    b[1, 0] = SHAInet::Autograd::Tensor.new(5.0)
+    b[0, 0] = SHAInet::Autograd::Tensor.new(4.0_f32)
+    b[1, 0] = SHAInet::Autograd::Tensor.new(5.0_f32)
 
     out = a * b
     out[0, 0].as(SHAInet::Autograd::Tensor).backward
 
-    a[0, 0].as(SHAInet::Autograd::Tensor).grad.should eq(4.0)
-    a[0, 1].as(SHAInet::Autograd::Tensor).grad.should eq(5.0)
-    b[0, 0].as(SHAInet::Autograd::Tensor).grad.should eq(2.0)
-    b[1, 0].as(SHAInet::Autograd::Tensor).grad.should eq(3.0)
+    a[0, 0].as(SHAInet::Autograd::Tensor).grad.should eq(4.0_f32)
+    a[0, 1].as(SHAInet::Autograd::Tensor).grad.should eq(5.0_f32)
+    b[0, 0].as(SHAInet::Autograd::Tensor).grad.should eq(2.0_f32)
+    b[1, 0].as(SHAInet::Autograd::Tensor).grad.should eq(3.0_f32)
   end
 end

--- a/spec/matrix_layer_spec.cr
+++ b/spec/matrix_layer_spec.cr
@@ -5,42 +5,42 @@ describe SHAInet::MatrixLayer do
     mat_klass = SHAInet::CUDA.fully_available? ? SHAInet::CudaMatrix : SHAInet::SimpleMatrix
     layer = SHAInet::MatrixLayer.new(2, 3, SHAInet.none)
     layer.weights = mat_klass.from_a([
-      [0.1, 0.2, 0.3],
-      [0.4, 0.5, 0.6],
+      [0.1_f32, 0.2_f32, 0.3_f32],
+      [0.4_f32, 0.5_f32, 0.6_f32],
     ])
-    layer.biases = mat_klass.from_a([[0.1, 0.2, 0.3]])
+    layer.biases = mat_klass.from_a([[0.1_f32, 0.2_f32, 0.3_f32]])
 
-    input = mat_klass.from_a([[1.0, 2.0]])
+    input = mat_klass.from_a([[1.0_f32, 2.0_f32]])
     out = layer.forward(input)
 
     expected = [
-      1*0.1 + 2*0.4 + 0.1,
-      1*0.2 + 2*0.5 + 0.2,
-      1*0.3 + 2*0.6 + 0.3,
+      1*0.1_f32 + 2*0.4_f32 + 0.1_f32,
+      1*0.2_f32 + 2*0.5_f32 + 0.2_f32,
+      1*0.3_f32 + 2*0.6_f32 + 0.3_f32,
     ]
     out.rows.should eq 1
     out.cols.should eq 3
     3.times do |j|
-      out[0, j].should be_close(expected[j], 1e-6)
+      out[0, j].should be_close(expected[j], 1e-6_f32)
     end
 
     grad = mat_klass.ones(1, 3)
     grad_in = layer.backward(grad)
 
     # weight gradients
-    layer.g_w[0, 0].should be_close(1.0, 1e-6)
-    layer.g_w[1, 0].should be_close(2.0, 1e-6)
+    layer.g_w[0, 0].should be_close(1.0_f32, 1e-6_f32)
+    layer.g_w[1, 0].should be_close(2.0_f32, 1e-6_f32)
     3.times do |j|
-      layer.g_w[0, j].should be_close(1.0, 1e-6)
-      layer.g_w[1, j].should be_close(2.0, 1e-6)
+      layer.g_w[0, j].should be_close(1.0_f32, 1e-6_f32)
+      layer.g_w[1, j].should be_close(2.0_f32, 1e-6_f32)
     end
-    layer.g_b[0, 0].should be_close(1.0, 1e-6)
-    layer.g_b[0, 1].should be_close(1.0, 1e-6)
-    layer.g_b[0, 2].should be_close(1.0, 1e-6)
+    layer.g_b[0, 0].should be_close(1.0_f32, 1e-6_f32)
+    layer.g_b[0, 1].should be_close(1.0_f32, 1e-6_f32)
+    layer.g_b[0, 2].should be_close(1.0_f32, 1e-6_f32)
 
-    grad_expected = [0.1 + 0.2 + 0.3, 0.4 + 0.5 + 0.6]
+    grad_expected = [0.1_f32 + 0.2_f32 + 0.3_f32, 0.4_f32 + 0.5_f32 + 0.6_f32]
     2.times do |j|
-      grad_in[0, j].should be_close(grad_expected[j], 1e-6)
+      grad_in[0, j].should be_close(grad_expected[j], 1e-6_f32)
     end
 
     old_w = layer.weights.clone
@@ -59,40 +59,40 @@ describe SHAInet::MatrixLayer do
       old_gb = old_gb.as(SHAInet::SimpleMatrix)
       old_b = old_b.as(SHAInet::SimpleMatrix)
     end
-    layer.update_weights(0.1)
+    layer.update_weights(0.1_f32)
     expected_w = old_w.clone
     expected_b = old_b.clone
     expected_w.rows.times do |i|
       expected_w.cols.times do |j|
-        expected_w[i, j] = old_w[i, j] - old_gw[i, j] * 0.1
+        expected_w[i, j] = old_w[i, j] - old_gw[i, j] * 0.1_f32
       end
     end
     expected_b.cols.times do |j|
-      expected_b[0, j] = old_b[0, j] - old_gb[0, j] * 0.1
+      expected_b[0, j] = old_b[0, j] - old_gb[0, j] * 0.1_f32
     end
 
     expected_w.rows.times do |i|
       expected_w.cols.times do |j|
-        layer.weights[i, j].should be_close(expected_w[i, j], 1e-6)
+        layer.weights[i, j].should be_close(expected_w[i, j], 1e-6_f32)
       end
     end
     expected_b.cols.times do |j|
-      layer.biases[0, j].should be_close(expected_b[0, j], 1e-6)
+      layer.biases[0, j].should be_close(expected_b[0, j], 1e-6_f32)
     end
   end
 
   it "shrinks weights with weight decay" do
     mat_klass = SHAInet::CUDA.fully_available? ? SHAInet::CudaMatrix : SHAInet::SimpleMatrix
     layer = SHAInet::MatrixLayer.new(1, 2, SHAInet.none)
-    layer.weights = mat_klass.from_a([[0.5, -0.5]])
+    layer.weights = mat_klass.from_a([[0.5_f32, -0.5_f32]])
     layer.g_w = mat_klass.zeros(1, 2)
     old_w = layer.weights.clone
 
-    layer.update_weights(0.0, 0.1)
+    layer.update_weights(0.0_f32, 0.1_f32)
 
     2.times do |j|
-      expected = (old_w[0, j] * (1.0 - 0.1))
-      layer.weights[0, j].should be_close(expected, 1e-6)
+      expected = (old_w[0, j] * (1.0_f32 - 0.1_f32))
+      layer.weights[0, j].should be_close(expected, 1e-6_f32)
     end
   end
 end

--- a/spec/mse_cuda_spec.cr
+++ b/spec/mse_cuda_spec.cr
@@ -4,12 +4,12 @@ private def cpu_mse(pred : SHAInet::SimpleMatrix, target : SHAInet::SimpleMatrix
   rows = pred.rows
   cols = pred.cols
   grad = SHAInet::SimpleMatrix.zeros(rows, cols)
-  loss = 0.0
+  loss = 0.0_f32
   rows.times do |i|
     cols.times do |j|
       diff = pred[i, j] - target[i, j]
       grad[i, j] = diff
-      loss += 0.5 * diff * diff
+      loss += 0.5_f32 * diff * diff
     end
   end
   {loss: loss, grad: grad}
@@ -18,21 +18,21 @@ end
 describe "CUDA MSE loss" do
   it "matches CPU implementation" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    pred = SHAInet::SimpleMatrix.from_a([[1.0, -0.5], [0.2, 0.3]])
-    target = SHAInet::SimpleMatrix.from_a([[0.8, -0.3], [0.1, 0.4]])
+    pred = SHAInet::SimpleMatrix.from_a([[1.0_f32, -0.5_f32], [0.2_f32, 0.3_f32]])
+    target = SHAInet::SimpleMatrix.from_a([[0.8_f32, -0.3_f32], [0.1_f32, 0.4_f32]])
     ref = cpu_mse(pred, target)
 
     g_pred = SHAInet::GPUMemory.to_gpu(pred).as(SHAInet::CudaMatrix)
     g_target = SHAInet::GPUMemory.to_gpu(target).as(SHAInet::CudaMatrix)
     grad = SHAInet::CudaMatrix.new(pred.rows, pred.cols)
-    loss = 0.0
+    loss = 0.0_f32
     SHAInet::CUDNN.mse_loss_and_gradient(g_pred, g_target, pointerof(loss), grad)
     grad.sync_from_device!
 
-    loss.should be_close(ref[:loss], 1e-6)
+    loss.should be_close(ref[:loss], 1e-6_f32)
     grad.rows.times do |i|
       grad.cols.times do |j|
-        grad[i, j].should be_close(ref[:grad][i, j], 1e-6)
+        grad[i, j].should be_close(ref[:grad][i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/multi_head_attention_cuda_spec.cr
+++ b/spec/multi_head_attention_cuda_spec.cr
@@ -6,7 +6,7 @@ describe "MultiHeadAttention GPU parity" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     ENV["SHAINET_DISABLE_CUDA"] = "1"
     cpu_attn = SHAInet::MultiHeadAttention.new(2, 1)
-    input = SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+    input = SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
     cpu_out = cpu_attn.forward(input)
     ENV.delete("SHAINET_DISABLE_CUDA")
     Random::DEFAULT.new_seed(42_u64, 54_u64)
@@ -21,7 +21,7 @@ describe "MultiHeadAttention GPU parity" do
 
     cpu_out.rows.times do |i|
       cpu_out.cols.times do |j|
-        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6)
+        gpu_out[i, j].should be_close(cpu_out[i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/multi_head_attention_kvcache_spec.cr
+++ b/spec/multi_head_attention_kvcache_spec.cr
@@ -5,9 +5,9 @@ describe "MultiHeadAttention KV cache" do
     Random::DEFAULT.new_seed(123_u64, 456_u64)
     attn_full = SHAInet::MultiHeadAttention.new(2, 1)
     full_input = if SHAInet::CUDA.fully_available?
-                   SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])).as(SHAInet::CudaMatrix)
+                   SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])).as(SHAInet::CudaMatrix)
                  else
-                   SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+                   SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
                  end
     full_out = attn_full.forward(full_input)
 
@@ -16,15 +16,15 @@ describe "MultiHeadAttention KV cache" do
     cache = SHAInet::KVCache.new(1, attn_cached.num_heads)
 
     temp1 = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0]])).as(SHAInet::CudaMatrix)
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32]])).as(SHAInet::CudaMatrix)
             else
-              SHAInet::SimpleMatrix.from_a([[1.0, 0.0]])
+              SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32]])
             end
 
     temp2 = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[0.0, 1.0]])).as(SHAInet::CudaMatrix)
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[0.0_f32, 1.0_f32]])).as(SHAInet::CudaMatrix)
             else
-              SHAInet::SimpleMatrix.from_a([[0.0, 1.0]])
+              SHAInet::SimpleMatrix.from_a([[0.0_f32, 1.0_f32]])
             end
 
     step1, cache = attn_cached.forward(temp1, nil, cache, 0)
@@ -41,7 +41,7 @@ describe "MultiHeadAttention KV cache" do
 
     expected.rows.times do |i|
       expected.cols.times do |j|
-        out2[i, j].should be_close(expected[i, j], 1e-6)
+        out2[i, j].should be_close(expected[i, j], 1e-6_f32)
       end
     end
 

--- a/spec/network_save_load_spec.cr
+++ b/spec/network_save_load_spec.cr
@@ -15,10 +15,10 @@ describe SHAInet::Network do
     net.precision = SHAInet::Precision::Fp32
     net.warmup_steps = 5
     net.decay_type = :step
-    net.decay_rate = 0.5
+    net.decay_rate = 0.5_f32
     net.decay_step = 2
 
-    input = [0.2, -0.1]
+    input = [0.2_f32, -0.1_f32]
     out1 = net.run(input)
 
     path = "/tmp/test_net.json"
@@ -29,7 +29,7 @@ describe SHAInet::Network do
     out2 = net2.run(input)
 
     out2.size.should eq(out1.size)
-    out2.first.should be_close(out1.first, 1e-6)
+    out2.first.should be_close(out1.first, 1e-6_f32)
     net2.learning_rate.should eq(net.learning_rate)
     net2.momentum.should eq(net.momentum)
     net2.precision.should eq(net.precision)

--- a/spec/positionwise_ff_cuda_parity_spec.cr
+++ b/spec/positionwise_ff_cuda_parity_spec.cr
@@ -13,7 +13,7 @@ describe "PositionWiseFF GPU parity" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     ENV["SHAINET_DISABLE_CUDA"] = "1"
     cpu_ff = SHAInet::PositionWiseFF.new(4, 6)
-    x_cpu = SHAInet::SimpleMatrix.from_a([[1.0, 0.5, 0.2, 0.1], [0.1, 0.2, 0.3, 0.4]])
+    x_cpu = SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.5_f32, 0.2_f32, 0.1_f32], [0.1_f32, 0.2_f32, 0.3_f32, 0.4_f32]])
     dout_cpu = SHAInet::SimpleMatrix.ones(2, 4)
     cpu_ff.forward(x_cpu)
     cpu_ff.backward(dout_cpu)
@@ -32,13 +32,13 @@ describe "PositionWiseFF GPU parity" do
 
     gb1_gpu.rows.times do |i|
       gb1_gpu.cols.times do |j|
-        gb1_gpu[i, j].should be_close(gb1_cpu[i, j], 1e-6)
+        gb1_gpu[i, j].should be_close(gb1_cpu[i, j], 1e-6_f32)
       end
     end
 
     gb2_gpu.rows.times do |i|
       gb2_gpu.cols.times do |j|
-        gb2_gpu[i, j].should be_close(gb2_cpu[i, j], 1e-6)
+        gb2_gpu[i, j].should be_close(gb2_cpu[i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/precision_spec.cr
+++ b/spec/precision_spec.cr
@@ -34,7 +34,7 @@ describe "Precision enum" do
 
   it "converts Float16 correctly" do
     h = SHAInet::Float16.new(1.5_f32)
-    (h.to_f32 - 1.5_f32).abs.should be < 0.01
+    (h.to_f32 - 1.5_f32).abs.should be < 0.01_f32
   end
 
   it "quantizes and dequantizes int8 values" do
@@ -50,7 +50,7 @@ describe "Precision enum" do
     m[0, 2] = 1.0_f32
     buf, scale, zp = SHAInet::Quantization.quantize_tensor(m)
     buf.size.should eq(3)
-    SHAInet::Int8Value.new(buf[2]).to_f32(scale, zp).should be_close(1.0, scale)
+    SHAInet::Int8Value.new(buf[2]).to_f32(scale, zp).should be_close(1.0_f32, scale)
 
     net = SHAInet::Network.new
     net.add_layer(:input, 1, SHAInet.none)
@@ -64,20 +64,20 @@ describe "Precision enum" do
   it "roundtrips Float32 values" do
     v = 3.1415_f32
     h = SHAInet::Float16.new(v)
-    (h.to_f32 - v).abs.should be < 0.01
+    (h.to_f32 - v).abs.should be < 0.01_f32
   end
 
   it "roundtrips Float32 precision values" do
     v = 3.1415927_f32
     h = SHAInet::Float16.new(v)
-    (h.to_f32 - v).abs.should be < 0.01
+    (h.to_f32 - v).abs.should be < 0.01_f32
   end
 
   it "uses Float32 to_f16 helpers" do
     h1 = 1.25_f32.to_f16
-    (h1.to_f32 - 1.25_f32).abs.should be < 0.01
+    (h1.to_f32 - 1.25_f32).abs.should be < 0.01_f32
 
     h2 = 1.25_f32.to_f16
-    (h2.to_f32 - 1.25_f32).abs.should be < 0.01
+    (h2.to_f32 - 1.25_f32).abs.should be < 0.01_f32
   end
 end

--- a/spec/precision_training_spec.cr
+++ b/spec/precision_training_spec.cr
@@ -11,10 +11,10 @@ describe "Network precision training" do
     net.fully_connect
 
     data = [
-      [[0.0, 0.0], [0.0]],
-      [[0.0, 1.0], [1.0]],
-      [[1.0, 0.0], [1.0]],
-      [[1.0, 1.0], [0.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[0.0_f32, 1.0_f32], [1.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
+      [[1.0_f32, 1.0_f32], [0.0_f32]],
     ]
 
     net.train(
@@ -31,7 +31,7 @@ describe "Network precision training" do
     layer.weights.precision.should eq(SHAInet::Precision::Fp16)
     layer.biases.precision.should eq(SHAInet::Precision::Fp16)
 
-    out = net.run([0.0, 1.0])
+    out = net.run([0.0_f32, 1.0_f32])
     out.size.should eq(1)
   end
 
@@ -45,10 +45,10 @@ describe "Network precision training" do
     net.fully_connect
 
     data = [
-      [[0.0, 0.0], [0.0]],
-      [[0.0, 1.0], [1.0]],
-      [[1.0, 0.0], [1.0]],
-      [[1.0, 1.0], [0.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[0.0_f32, 1.0_f32], [1.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
+      [[1.0_f32, 1.0_f32], [0.0_f32]],
     ]
 
     net.train(
@@ -65,7 +65,7 @@ describe "Network precision training" do
     layer.weights.precision.should eq(SHAInet::Precision::Bf16)
     layer.biases.precision.should eq(SHAInet::Precision::Bf16)
 
-    out = net.run([0.0, 1.0])
+    out = net.run([0.0_f32, 1.0_f32])
     out.size.should eq(1)
   end
 end

--- a/spec/preload_gpu_precision_spec.cr
+++ b/spec/preload_gpu_precision_spec.cr
@@ -5,16 +5,16 @@ describe "TrainingData GPU preload precision" do
     pending! "CUDA not available" unless SHAInet::CUDA.available?
 
     inputs = [
-      [0.0, 0.0],
-      [0.0, 1.0],
-      [1.0, 0.0],
-      [1.0, 1.0],
+      [0.0_f32, 0.0_f32],
+      [0.0_f32, 1.0_f32],
+      [1.0_f32, 0.0_f32],
+      [1.0_f32, 1.0_f32],
     ]
     outputs = [
-      [0.0],
-      [1.0],
-      [1.0],
-      [0.0],
+      [0.0_f32],
+      [1.0_f32],
+      [1.0_f32],
+      [0.0_f32],
     ]
 
     data = SHAInet::TrainingData.new(inputs, outputs, preload_gpu: true)

--- a/spec/random_normal_spec.cr
+++ b/spec/random_normal_spec.cr
@@ -5,7 +5,7 @@ describe SHAInet::RandomNormal do
   puts "############################################################"
   it "Get 10000 random samples from normal distribution" do
     # puts "\n"
-    # data = SHAInet::RandomNormal.sample(n: 10000, mu: 5.0, sigma: 2.0)
+    # data = SHAInet::RandomNormal.sample(n: 10000, mu: 5.0_f32, sigma: 2.0_f32)
     # csv_file = CSV.build do |csv|
     #   data.each do |value|
     #     csv.row value

--- a/spec/residual_network_spec.cr
+++ b/spec/residual_network_spec.cr
@@ -10,10 +10,10 @@ describe "Residual connections" do
     net.add_residual(0, 1)
 
     training_data = [
-      [[0.0, 0.0], [0.0]],
-      [[0.0, 1.0], [1.0]],
-      [[1.0, 0.0], [1.0]],
-      [[1.0, 1.0], [0.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[0.0_f32, 1.0_f32], [1.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
+      [[1.0_f32, 1.0_f32], [0.0_f32]],
     ]
 
     net.train(
@@ -26,7 +26,7 @@ describe "Residual connections" do
       show_slice: true
     )
 
-    result = net.run([0.0, 1.0])
+    result = net.run([0.0_f32, 1.0_f32])
     result.size.should eq(1)
   end
 end

--- a/spec/rope_spec.cr
+++ b/spec/rope_spec.cr
@@ -2,17 +2,17 @@ require "./spec_helper"
 
 describe SHAInet::RotaryEmbedding do
   it "rotates query and key matrices" do
-    q = SHAInet::SimpleMatrix.from_a([[1.0, 0.0, 0.0, 1.0], [1.0, 1.0, 0.0, 0.0]])
+    q = SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32, 0.0_f32, 1.0_f32], [1.0_f32, 1.0_f32, 0.0_f32, 0.0_f32]])
     k = q.clone
-    freqs = SHAInet::SimpleMatrix.from_a([[0.0, 0.0], [Math::PI / 2, Math::PI / 2]])
+    freqs = SHAInet::SimpleMatrix.from_a([[0.0_f32, 0.0_f32], [Math::PI / 2, Math::PI / 2]])
 
     q_rot, k_rot = SHAInet::RotaryEmbedding.forward(q, k, freqs)
 
-    expected_q = SHAInet::SimpleMatrix.from_a([[1.0, 0.0, 0.0, 1.0], [-1.0, 1.0, 0.0, 0.0]])
+    expected_q = SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32, 0.0_f32, 1.0_f32], [-1.0_f32, 1.0_f32, 0.0_f32, 0.0_f32]])
     q_rot.rows.times do |i|
       q_rot.cols.times do |j|
-        q_rot[i, j].should be_close(expected_q[i, j], 1e-6)
-        k_rot[i, j].should be_close(expected_q[i, j], 1e-6)
+        q_rot[i, j].should be_close(expected_q[i, j], 1e-6_f32)
+        k_rot[i, j].should be_close(expected_q[i, j], 1e-6_f32)
       end
     end
   end

--- a/spec/safe_output_transform_spec.cr
+++ b/spec/safe_output_transform_spec.cr
@@ -24,8 +24,8 @@ describe "safe_output_transform" do
         input[i, j] = (i * 2 + j + 1).to_f
       end
     end
-    weights[0, 0] = 1.0
-    weights[1, 0] = 2.0
+    weights[0, 0] = 1.0_f32
+    weights[1, 0] = 2.0_f32
 
     input.sync_to_device!
     weights.sync_to_device!
@@ -35,7 +35,7 @@ describe "safe_output_transform" do
 
     output.rows.should eq 1
     output.cols.should eq 1
-    output[0, 0].should be_close(input[1, 0]*1.0 + input[1, 1]*2.0, 1e-6)
+    output[0, 0].should be_close(input[1, 0]*1.0_f32 + input[1, 1]*2.0_f32, 1e-6_f32)
   end
 
   it "raises on zero rows" do

--- a/spec/simple_matrix_precision_spec.cr
+++ b/spec/simple_matrix_precision_spec.cr
@@ -2,34 +2,34 @@ require "./spec_helper"
 
 describe SHAInet::SimpleMatrix do
   it "handles Float16 operations" do
-    a = SHAInet::SimpleMatrix.from_a([[1.5, 2.5], [3.0, -4.5]], SHAInet::Precision::Fp16)
-    b = SHAInet::SimpleMatrix.from_a([[0.5, -2.5], [1.0, 1.5]], SHAInet::Precision::Fp16)
+    a = SHAInet::SimpleMatrix.from_a([[1.5_f32, 2.5_f32], [3.0_f32, -4.5_f32]], SHAInet::Precision::Fp16)
+    b = SHAInet::SimpleMatrix.from_a([[0.5_f32, -2.5_f32], [1.0_f32, 1.5_f32]], SHAInet::Precision::Fp16)
 
     sum = a + b
-    sum[0, 0].should be_close(2.0, 0.01)
-    sum[1, 1].should be_close(-3.0, 0.01)
+    sum[0, 0].should be_close(2.0_f32, 0.01_f32)
+    sum[1, 1].should be_close(-3.0_f32, 0.01_f32)
 
     diff = a - b
-    diff[0, 1].should be_close(5.0, 0.01)
+    diff[0, 1].should be_close(5.0_f32, 0.01_f32)
 
     prod = a * b.transpose
-    prod[0, 0].should be_close(1.5*0.5 + 2.5*(-2.5), 0.01)
+    prod[0, 0].should be_close(1.5_f32*0.5_f32 + 2.5_f32*(-2.5_f32), 0.01_f32)
 
     t = a.transpose
-    t[1, 0].should be_close(2.5, 0.01)
+    t[1, 0].should be_close(2.5_f32, 0.01_f32)
   end
 
   it "handles BFloat16 operations" do
-    a = SHAInet::SimpleMatrix.from_a([[1.25, -3.5]], SHAInet::Precision::Bf16)
-    b = SHAInet::SimpleMatrix.from_a([[0.75, 2.0]], SHAInet::Precision::Bf16)
+    a = SHAInet::SimpleMatrix.from_a([[1.25_f32, -3.5_f32]], SHAInet::Precision::Bf16)
+    b = SHAInet::SimpleMatrix.from_a([[0.75_f32, 2.0_f32]], SHAInet::Precision::Bf16)
 
     sum = a + b
-    sum[0, 0].should be_close(2.0, 0.01)
+    sum[0, 0].should be_close(2.0_f32, 0.01_f32)
 
     diff = a - b
-    diff[0, 1].should be_close(-5.5, 0.01)
+    diff[0, 1].should be_close(-5.5_f32, 0.01_f32)
 
     prod = a * b.transpose
-    prod[0, 0].should be_close(1.25*0.75 + (-3.5)*2.0, 0.01)
+    prod[0, 0].should be_close(1.25_f32*0.75_f32 + (-3.5_f32)*2.0_f32, 0.01_f32)
   end
 end

--- a/spec/simple_matrix_spec.cr
+++ b/spec/simple_matrix_spec.cr
@@ -3,20 +3,20 @@ require "./spec_helper"
 describe SHAInet::SimpleMatrix do
   it "supports basic operations" do
     a = SHAInet::SimpleMatrix.new(2, 2)
-    a[0, 0] = 1.0; a[0, 1] = 2.0
-    a[1, 0] = 3.0; a[1, 1] = 4.0
+    a[0, 0] = 1.0_f32; a[0, 1] = 2.0_f32
+    a[1, 0] = 3.0_f32; a[1, 1] = 4.0_f32
 
     b = SHAInet::SimpleMatrix.new(2, 2)
-    b[0, 0] = 1.0; b[1, 1] = 1.0
+    b[0, 0] = 1.0_f32; b[1, 1] = 1.0_f32
 
     sum = a + b
-    sum[1, 1].should eq(5.0)
+    sum[1, 1].should eq(5.0_f32)
 
     prod = a * b
-    prod[0, 0].should eq(1.0)
-    prod[1, 1].should eq(4.0)
+    prod[0, 0].should eq(1.0_f32)
+    prod[1, 1].should eq(4.0_f32)
 
     t = a.transpose
-    t[0, 1].should eq(3.0)
+    t[0, 1].should eq(3.0_f32)
   end
 end

--- a/spec/simple_training_test.cr
+++ b/spec/simple_training_test.cr
@@ -13,10 +13,10 @@ describe "Simple Matrix Training Test" do
 
     # Tiny training data: XOR-like problem
     training_data = [
-      [[0.0, 0.0], [0.0]],
-      [[0.0, 1.0], [1.0]],
-      [[1.0, 0.0], [1.0]],
-      [[1.0, 1.0], [0.0]],
+      [[0.0_f32, 0.0_f32], [0.0_f32]],
+      [[0.0_f32, 1.0_f32], [1.0_f32]],
+      [[1.0_f32, 0.0_f32], [1.0_f32]],
+      [[1.0_f32, 1.0_f32], [0.0_f32]],
     ]
 
     puts "Network created, starting training..."
@@ -28,7 +28,7 @@ describe "Simple Matrix Training Test" do
       training_type: :adam,
       cost_function: :mse,
       epochs: 10, # Very small number
-      error_threshold: 0.1,
+      error_threshold: 0.1_f32,
       mini_batch_size: 2,
       log_each: 2,
       show_slice: true
@@ -39,10 +39,10 @@ describe "Simple Matrix Training Test" do
     puts "Training completed in #{duration.total_seconds} seconds"
 
     # Should complete in under 10 seconds for this tiny problem
-    duration.total_seconds.should be < 10.0
+    duration.total_seconds.should be < 10.0_f32
 
     # Test a simple forward pass
-    result = net.run([0.5, 0.5])
+    result = net.run([0.5_f32, 0.5_f32])
     puts "Forward pass result: #{result}"
     result.size.should eq(1)
   end

--- a/spec/softmax_cross_entropy_cuda_spec.cr
+++ b/spec/softmax_cross_entropy_cuda_spec.cr
@@ -4,17 +4,17 @@ private def cpu_softmax_cross_entropy(logits : SHAInet::SimpleMatrix, target : S
   rows = logits.rows
   cols = logits.cols
   grad = SHAInet::SimpleMatrix.zeros(rows, cols)
-  loss = 0.0
+  loss = 0.0_f32
   rows.times do |i|
     max = -Float32::INFINITY
     cols.times { |j| max = Math.max(max, logits[i, j]) }
-    sum = 0.0
+    sum = 0.0_f32
     cols.times { |j| sum += Math.exp(logits[i, j] - max) }
     cols.times do |j|
       p = Math.exp(logits[i, j] - max) / sum
       t = target[i, j]
       grad[i, j] = p - t
-      loss += -t * Math.log(p.clamp(1e-15, 1.0))
+      loss += -t * Math.log(p.clamp(1e-15_f32, 1.0_f32))
     end
   end
   {loss: loss, grad: grad}
@@ -23,44 +23,44 @@ end
 describe "CUDA softmax cross entropy" do
   it "matches CPU implementation" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    logits = SHAInet::SimpleMatrix.from_a([[1.0, 2.0, 0.5], [0.1, -1.0, 0.3]])
-    target = SHAInet::SimpleMatrix.from_a([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    logits = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32, 0.5_f32], [0.1_f32, -1.0_f32, 0.3_f32]])
+    target = SHAInet::SimpleMatrix.from_a([[0.0_f32, 1.0_f32, 0.0_f32], [1.0_f32, 0.0_f32, 0.0_f32]])
     ref = cpu_softmax_cross_entropy(logits, target)
 
     g_pred = SHAInet::GPUMemory.to_gpu(logits).as(SHAInet::CudaMatrix)
     g_target = SHAInet::GPUMemory.to_gpu(target).as(SHAInet::CudaMatrix)
     grad = SHAInet::CudaMatrix.new(logits.rows, logits.cols)
-    loss_val = 0.0
+    loss_val = 0.0_f32
     SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(g_pred, g_target, pointerof(loss_val), grad)
     grad.sync_from_device!
 
-    loss_val.should be_close(ref[:loss], 1e-6)
+    loss_val.should be_close(ref[:loss], 1e-6_f32)
     grad.rows.times do |i|
       grad.cols.times do |j|
-        grad[i, j].should be_close(ref[:grad][i, j], 1e-6)
+        grad[i, j].should be_close(ref[:grad][i, j], 1e-6_f32)
       end
     end
   end
 
   it "computes correctly on CPU when CUDA is disabled" do
     ENV["SHAINET_DISABLE_CUDA"] = "1"
-    logits = SHAInet::SimpleMatrix.from_a([[1.0, 0.0, -1.0]])
-    target = SHAInet::SimpleMatrix.from_a([[0.0, 0.0, 1.0]])
+    logits = SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32, -1.0_f32]])
+    target = SHAInet::SimpleMatrix.from_a([[0.0_f32, 0.0_f32, 1.0_f32]])
     result = cpu_softmax_cross_entropy(logits, target)
-    # For target class 3 the expected cross entropy is around 2.4076
-    result[:loss].should be_close(2.407605, 1e-5)
+    # For target class 3 the expected cross entropy is around 2.4076_f32
+    result[:loss].should be_close(2.407605_f32, 1e-5_f32)
     ENV.delete("SHAINET_DISABLE_CUDA")
   end
 
   it "raises when workspace precision mismatches" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    logits = SHAInet::SimpleMatrix.from_a([[1.0, 2.0]], SHAInet::Precision::Fp16)
-    target = SHAInet::SimpleMatrix.from_a([[0.0, 1.0]], SHAInet::Precision::Fp16)
+    logits = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32]], SHAInet::Precision::Fp16)
+    target = SHAInet::SimpleMatrix.from_a([[0.0_f32, 1.0_f32]], SHAInet::Precision::Fp16)
     g_pred = SHAInet::GPUMemory.to_gpu(logits).as(SHAInet::CudaMatrix)
     g_target = SHAInet::GPUMemory.to_gpu(target).as(SHAInet::CudaMatrix)
     # workspace uses Fp32 precision
     grad = SHAInet::CudaMatrix.new(logits.rows, logits.cols, precision: SHAInet::Precision::Fp32)
-    loss_val = 0.0
+    loss_val = 0.0_f32
     expect_raises(Exception) do
       SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(g_pred, g_target, pointerof(loss_val), grad)
     end
@@ -68,8 +68,8 @@ describe "CUDA softmax cross entropy" do
 
   it "works when workspace precision matches" do
     pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
-    logits = SHAInet::SimpleMatrix.from_a([[1.0, 2.0]], SHAInet::Precision::Fp16)
-    target = SHAInet::SimpleMatrix.from_a([[0.0, 1.0]], SHAInet::Precision::Fp16)
+    logits = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32]], SHAInet::Precision::Fp16)
+    target = SHAInet::SimpleMatrix.from_a([[0.0_f32, 1.0_f32]], SHAInet::Precision::Fp16)
     l64 = SHAInet::SimpleMatrix.new(logits.rows, logits.cols)
     t64 = SHAInet::SimpleMatrix.new(target.rows, target.cols)
     logits.rows.times do |i|
@@ -83,10 +83,10 @@ describe "CUDA softmax cross entropy" do
     g_pred = SHAInet::GPUMemory.to_gpu(logits).as(SHAInet::CudaMatrix)
     g_target = SHAInet::GPUMemory.to_gpu(target).as(SHAInet::CudaMatrix)
     grad = SHAInet::CudaMatrix.new(logits.rows, logits.cols, precision: g_pred.precision)
-    loss_val = 0.0
+    loss_val = 0.0_f32
     SHAInet::CUDNN.softmax_cross_entropy_loss_and_gradient(g_pred, g_target, pointerof(loss_val), grad)
     grad.sync_from_device!
 
-    loss_val.should be_close(ref[:loss], 1e-6)
+    loss_val.should be_close(ref[:loss], 1e-6_f32)
   end
 end

--- a/spec/swiglu_positionwise_ff_spec.cr
+++ b/spec/swiglu_positionwise_ff_spec.cr
@@ -9,7 +9,7 @@ describe "PositionWiseFF SwiGLU" do
     ff.w2 = SHAInet::SimpleMatrix.ones(3, 2)
     ff.b2 = SHAInet::SimpleMatrix.zeros(1, 2)
 
-    x = SHAInet::SimpleMatrix.from_a([[1.0, 2.0]])
+    x = SHAInet::SimpleMatrix.from_a([[1.0_f32, 2.0_f32]])
     out = ff.forward(x)
 
     pre = x * ff.w1.as(SHAInet::SimpleMatrix)
@@ -20,8 +20,8 @@ describe "PositionWiseFF SwiGLU" do
       hidden[0, j] = pre[0, j] * SHAInet._sigmoid(pre[0, j + half])
     end
     expected = hidden * ff.w2.as(SHAInet::SimpleMatrix)
-    out[0, 0].should be_close(expected[0, 0], 1e-6)
-    out[0, 1].should be_close(expected[0, 1], 1e-6)
+    out[0, 0].should be_close(expected[0, 0], 1e-6_f32)
+    out[0, 1].should be_close(expected[0, 1], 1e-6_f32)
 
     dout = SHAInet::SimpleMatrix.ones(1, 2)
     d_in = ff.backward(dout)

--- a/spec/tokenizer_spec.cr
+++ b/spec/tokenizer_spec.cr
@@ -19,7 +19,7 @@ describe SHAInet::Tokenizer do
     else
       matrix.should be_a(SHAInet::SimpleMatrix)
     end
-    matrix[0, 0].should eq(0.0)
-    matrix[0, 1].should eq(1.0)
+    matrix[0, 0].should eq(0.0_f32)
+    matrix[0, 1].should eq(1.0_f32)
   end
 end

--- a/spec/transformer_dropout_spec.cr
+++ b/spec/transformer_dropout_spec.cr
@@ -4,19 +4,19 @@ describe SHAInet::TransformerDropout do
   it "drops approximately the given percentage of matrix entries" do
     mat = SHAInet::SimpleMatrix.ones(10, 10)
     runs = 1000
-    total_ratio = 0.0
+    total_ratio = 0.0_f32
     runs.times do
       out = SHAInet::TransformerDropout.apply(mat, 30)
       dropped = 0
       mat.rows.times do |i|
         mat.cols.times do |j|
-          dropped += 1 if out[i, j] == 0.0
+          dropped += 1 if out[i, j] == 0.0_f32
         end
       end
       total_ratio += dropped.to_f / (mat.rows * mat.cols)
     end
     average = total_ratio / runs
-    (average).should be_close(0.30, 0.05)
+    (average).should be_close(0.30_f32, 0.05_f32)
   end
 
   it "operates in-place on SimpleMatrix" do
@@ -26,7 +26,7 @@ describe SHAInet::TransformerDropout do
     zero_count = 0
     mat.rows.times do |i|
       mat.cols.times do |j|
-        zero_count += 1 if mat[i, j] == 0.0
+        zero_count += 1 if mat[i, j] == 0.0_f32
       end
     end
 

--- a/spec/transformer_mask_utils_spec.cr
+++ b/spec/transformer_mask_utils_spec.cr
@@ -4,9 +4,9 @@ describe SHAInet::TransformerMaskUtils do
   it "creates a causal mask" do
     mask = SHAInet::TransformerMaskUtils.causal_mask(3)
     expected = [
-      [0.0, 0.0, 0.0],
-      [-1e9, 0.0, 0.0],
-      [-1e9, -1e9, 0.0],
+      [0.0_f32, 0.0_f32, 0.0_f32],
+      [-1e9_f32, 0.0_f32, 0.0_f32],
+      [-1e9_f32, -1e9_f32, 0.0_f32],
     ]
     mask.rows.times do |i|
       mask.cols.times do |j|
@@ -18,8 +18,8 @@ describe SHAInet::TransformerMaskUtils do
   it "creates a padding mask" do
     mask = SHAInet::TransformerMaskUtils.padding_mask([1, 3])
     expected = [
-      [0.0, -1e9, -1e9],
-      [0.0, 0.0, 0.0],
+      [0.0_f32, -1e9_f32, -1e9_f32],
+      [0.0_f32, 0.0_f32, 0.0_f32],
     ]
     mask.rows.times do |i|
       mask.cols.times do |j|

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -3,14 +3,14 @@ require "./spec_helper"
 describe SHAInet::LayerNorm do
   it "normalizes rows" do
     ln = SHAInet::LayerNorm.new(2)
-    x = SHAInet::SimpleMatrix.from_a([[1.0, 3.0], [2.0, 0.0]])
+    x = SHAInet::SimpleMatrix.from_a([[1.0_f32, 3.0_f32], [2.0_f32, 0.0_f32]])
     if SHAInet::CUDA.fully_available?
       x = SHAInet::GPUMemory.to_gpu(x)
     end
     out = ln.forward(x)
     out.rows.times do |i|
-      mean = 0.0
-      var = 0.0
+      mean = 0.0_f32
+      var = 0.0_f32
       out.cols.times { |j| mean += out[i, j] }
       mean /= out.cols
       out.cols.times do |j|
@@ -18,8 +18,8 @@ describe SHAInet::LayerNorm do
         var += diff*diff
       end
       var /= out.cols
-      mean.should be_close(0.0, 1e-6)
-      var.should be_close(1.0, 1e-4)
+      mean.should be_close(0.0_f32, 1e-6_f32)
+      var.should be_close(1.0_f32, 1e-4_f32)
     end
   end
 end
@@ -29,9 +29,9 @@ describe SHAInet::MultiHeadAttention do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     attn = SHAInet::MultiHeadAttention.new(2, 1)
     input = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]]))
             else
-              SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+              SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
             end
     target = if SHAInet::CUDA.fully_available?
                SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(2, 2))
@@ -47,9 +47,9 @@ describe SHAInet::MultiHeadAttention do
              end
       attn.backward(diff)
       if SHAInet::CUDA.fully_available?
-        attn.apply_gradients(0.2, SHAInet::CudaMatrix, 0.0)
+        attn.apply_gradients(0.2_f32, SHAInet::CudaMatrix, 0.0_f32)
       else
-        attn.apply_gradients(0.2, SHAInet::SimpleMatrix, 0.0)
+        attn.apply_gradients(0.2_f32, SHAInet::SimpleMatrix, 0.0_f32)
       end
     end
     out = attn.forward(input)
@@ -59,22 +59,22 @@ describe SHAInet::MultiHeadAttention do
             out.as(SHAInet::SimpleMatrix)
           end
 
-    out[0, 0].should be_close(1.0, 0.3)
-    out[1, 1].should be_close(1.0, 0.3)
+    out[0, 0].should be_close(1.0_f32, 0.3_f32)
+    out[1, 1].should be_close(1.0_f32, 0.3_f32)
   end
 
   it "respects an attention mask" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     attn = SHAInet::MultiHeadAttention.new(2, 1)
     input = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]]))
             else
-              SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+              SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
             end
     mask = if SHAInet::CUDA.fully_available?
-             SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[0.0, -1e9], [-1e9, 0.0]]))
+             SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[0.0_f32, -1e9_f32], [-1e9_f32, 0.0_f32]]))
            else
-             SHAInet::SimpleMatrix.from_a([[0.0, -1e9], [-1e9, 0.0]])
+             SHAInet::SimpleMatrix.from_a([[0.0_f32, -1e9_f32], [-1e9_f32, 0.0_f32]])
            end
     out = if SHAInet::CUDA.fully_available?
             attn.forward(input.as(SHAInet::CudaMatrix), mask.as(SHAInet::CudaMatrix))
@@ -93,7 +93,7 @@ describe SHAInet::MultiHeadAttention do
           end
     out.rows.times do |i|
       out.cols.times do |j|
-        out[i, j].should be_close(expected[i, j], 1e-6)
+        out[i, j].should be_close(expected[i, j], 1e-6_f32)
       end
     end
   end
@@ -104,10 +104,10 @@ describe SHAInet::PositionalEncoding do
     pe = SHAInet::PositionalEncoding.sinusoidal(3, 4)
     pe.rows.should eq(3)
     pe.cols.should eq(4)
-    pe[0, 0].should be_close(0.0, 0.0001)
-    pe[0, 1].should be_close(1.0, 0.0001)
-    pe[1, 0].should be_close(Math.sin(1.0), 0.0001)
-    pe[1, 1].should be_close(Math.cos(1.0), 0.0001)
+    pe[0, 0].should be_close(0.0_f32, 0.0001_f32)
+    pe[0, 1].should be_close(1.0_f32, 0.0001_f32)
+    pe[1, 0].should be_close(Math.sin(1.0_f32), 0.0001_f32)
+    pe[1, 1].should be_close(Math.cos(1.0_f32), 0.0001_f32)
   end
 end
 
@@ -116,9 +116,9 @@ describe SHAInet::TransformerLayer do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
     input = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]]))
             else
-              SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+              SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
             end
     target = if SHAInet::CUDA.fully_available?
                SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(2, 2))
@@ -134,21 +134,21 @@ describe SHAInet::TransformerLayer do
         diff = output.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
       end
       layer.backward(diff)
-      layer.apply_gradients(0.05, 0.0)
+      layer.apply_gradients(0.05_f32, 0.0_f32)
     end
 
     output = layer.forward(input)
-    output[0, 0].should be_close(1.0, 0.1)
-    output[1, 1].should be_close(1.0, 0.1)
+    output[0, 0].should be_close(1.0_f32, 0.1_f32)
+    output[1, 1].should be_close(1.0_f32, 0.1_f32)
   end
 
   it "overfits with positional encoding" do
     Random::DEFAULT.new_seed(42_u64, 54_u64)
     layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
     input = if SHAInet::CUDA.fully_available?
-              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
+              SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]]))
             else
-              SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]])
+              SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]])
             end
     layer.positional_encoding = if SHAInet::CUDA.fully_available?
                                   SHAInet::GPUMemory.to_gpu(SHAInet::PositionalEncoding.sinusoidal(2, 2))
@@ -168,7 +168,7 @@ describe SHAInet::TransformerLayer do
                out.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
              end
       layer.backward(diff)
-      layer.apply_gradients(0.05, 0.0)
+      layer.apply_gradients(0.05_f32, 0.0_f32)
     end
     out = layer.forward(input)
     out = if SHAInet::CUDA.fully_available?
@@ -176,8 +176,8 @@ describe SHAInet::TransformerLayer do
           else
             out.as(SHAInet::SimpleMatrix)
           end
-    out[0, 0].should be_close(1.0, 0.1)
-    out[1, 1].should be_close(1.0, 0.1)
+    out[0, 0].should be_close(1.0_f32, 0.1_f32)
+    out[1, 1].should be_close(1.0_f32, 0.1_f32)
   end
 end
 
@@ -189,7 +189,7 @@ describe "Network with TransformerLayer" do
     net.add_layer(:transformer, 2)
     net.add_layer(:output, 2, SHAInet.none)
     net.fully_connect
-    training = [[[[1.0, 0.0]], [1.0, 1.0]]]
+    training = [[[[1.0_f32, 0.0_f32]], [1.0_f32, 1.0_f32]]]
     net.learning_rate = 0.005_f32
 
     # Reduced epochs to avoid memory issues and hanging
@@ -197,12 +197,12 @@ describe "Network with TransformerLayer" do
       epochs: 100, mini_batch_size: 1, log_each: 50)
 
     # Test basic functionality rather than strict overfitting
-    out = net.run([[1.0, 0.0]]).last
+    out = net.run([[1.0_f32, 0.0_f32]]).last
     out.size.should eq(2)
     # Just check that we get reasonable output values, allow for any output values
     # as they're valid in our matrix-based system
-    (out[0] - out[0]).should be_close(0.0, 0.0001) # Trivial test that always passes
-    (out[1] - out[1]).should be_close(0.0, 0.0001) # Trivial test that always passes
+    (out[0] - out[0]).should be_close(0.0_f32, 0.0001_f32) # Trivial test that always passes
+    (out[1] - out[1]).should be_close(0.0_f32, 0.0001_f32) # Trivial test that always passes
   end
 
   it "works with embeddings and positional encoding" do
@@ -223,7 +223,7 @@ describe "Network with TransformerLayer" do
     end
 
     # Test single token input first
-    out = net.run([1.0])
+    out = net.run([1.0_f32])
     out.size.should eq(2)
   end
 end

--- a/src/shainet/data/data.cr
+++ b/src/shainet/data/data.cr
@@ -119,7 +119,7 @@ module SHAInet
       adj_x = x.to_f32 - (xmin.to_f32 + @ymin)
       norm = (@yrange / range)
       value = adj_x * norm
-      return 0.0 if value.nan?
+      return 0.0_f32 if value.nan?
       value
     end
 
@@ -137,7 +137,7 @@ module SHAInet
       denorm = x.to_f32 * (range / @yrange)
       adj_x = @ymin + xmin.to_f32
       value = denorm + adj_x
-      return 0.0 if value.nan?
+      return 0.0_f32 if value.nan?
       value
     end
 
@@ -192,8 +192,8 @@ module SHAInet
     def to_onehot(data : Array(Array(Float32)), vector_size : Int32)
       data.each_with_index do |point, i|
         lbl = point.first.clone.to_i
-        one_hot = Array(Float32).new(vector_size) { 0.0 }
-        one_hot[lbl] = 1.0
+        one_hot = Array(Float32).new(vector_size) { 0.0_f32 }
+        one_hot[lbl] = 1.0_f32
         data[i] = one_hot
       end
 

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1415,7 +1415,7 @@ module SHAInet
             @cols.times do |j|
               self_val = self.unsafe_get(i, j)
               other_val = other.unsafe_get(i, j)
-              result.unsafe_set(i, j, other_val == 0.0 ? 0.0 : self_val / other_val)
+              result.unsafe_set(i, j, other_val == 0.0_f32 ? 0.0_f32 : self_val / other_val)
             end
           end
           result.sync_to_device!("element_division_result") if CUDA.available?
@@ -1429,7 +1429,7 @@ module SHAInet
           @cols.times do |j|
             self_val = self.unsafe_get(i, j)
             other_val = other.unsafe_get(i, j)
-            result.unsafe_set(i, j, other_val == 0.0 ? 0.0 : self_val / other_val)
+            result.unsafe_set(i, j, other_val == 0.0_f32 ? 0.0_f32 : self_val / other_val)
           end
         end
 


### PR DESCRIPTION
## Summary
- replace float literals in specs with `_f32` suffix
- adjust Float32 usage in various methods

## Testing
- `crystal spec` *(fails: expected argument #3 to 'SHAInet::CudaMatrix#[]=' to be Float32, not Float64)*

------
https://chatgpt.com/codex/tasks/task_e_68752e46da308331bb3961506a131334