### PR TITLE
Update example numeric literals to Float32

### DIFF
--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -172,11 +172,11 @@ net.train(data: train_data,
 
 # Validation after training is complete
 puts "Training complete. Running validation..."
-val_loss = 0.0
+val_loss = 0.0_f32
 count = 0
 
 while (val_batch = val_data.next_batch(val_batch_size)).size > 0
-  total_batch_loss = 0.0
+  total_batch_loss = 0.0_f32
 
   val_batch.each do |sample|
     # sample is likely an Array: [input, target], but input can be various types
@@ -235,7 +235,7 @@ while (val_batch = val_data.next_batch(val_batch_size)).size > 0
 
     # Use native softmax - it's already optimized
     probs = SHAInet.softmax(output_vec)
-    total_batch_loss += -Math.log(probs[target_id].clamp(1e-9, 1.0))
+    total_batch_loss += -Math.log(probs[target_id].clamp(1e-9_f32, 1.0_f32))
     count += 1
   end
 

--- a/examples/quantize_int8.cr
+++ b/examples/quantize_int8.cr
@@ -5,10 +5,10 @@ ENV["SHAINET_DISABLE_CUDA"] = "1"
 
 # XOR training data
 DATA = [
-  [[0.0, 0.0], [0.0]],
-  [[1.0, 0.0], [1.0]],
-  [[0.0, 1.0], [1.0]],
-  [[1.0, 1.0], [0.0]],
+  [[0.0_f32, 0.0_f32], [0.0_f32]],
+  [[1.0_f32, 0.0_f32], [1.0_f32]],
+  [[0.0_f32, 1.0_f32], [1.0_f32]],
+  [[1.0_f32, 1.0_f32], [0.0_f32]],
 ]
 
 # Build a tiny network
@@ -28,10 +28,10 @@ net.train(
 )
 
 # Inference before quantization
-puts "Full precision output: #{net.run([1.0, 0.0])[0]}"
+puts "Full precision output: #{net.run([1.0_f32, 0.0_f32])[0]}"
 
 # Quantize weights and switch to INT8 inference
 net.quantize_int8!
 net.precision = SHAInet::Precision::Int8
 
-puts "INT8 output: #{net.run([1.0, 0.0])[0]}"
+puts "INT8 output: #{net.run([1.0_f32, 0.0_f32])[0]}"

--- a/examples/transformer_lm.cr
+++ b/examples/transformer_lm.cr
@@ -24,7 +24,7 @@ net.add_layer(:transformer, 8)
 net.add_layer(:output, token_count, SHAInet.sigmoid)
 net.fully_connect
 net.warmup_steps = 10
-net.weight_decay = 0.01
+net.weight_decay = 0.01_f32
 # Accumulate gradients over 2 batches before updating weights
 net.accumulation_steps = 2
 # Use reduced precision for faster training

--- a/examples/transformer_pe.cr
+++ b/examples/transformer_pe.cr
@@ -6,7 +6,7 @@ require "../src/shainet"
 layer = SHAInet::TransformerLayer.new(2, 1, 4, 0, false, SHAInet.relu)
 
 # Two-step input sequence (2 x 2 matrix)
-input = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0, 0.0], [0.0, 1.0]]))
+input = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.from_a([[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]]))
 
 # Generate positional encodings matching the input size
 pos_enc = SHAInet::PositionalEncoding.sinusoidal(input.rows, input.cols)
@@ -29,7 +29,7 @@ target = SHAInet::GPUMemory.to_gpu(SHAInet::SimpleMatrix.ones(2, 2))
            out.as(SHAInet::SimpleMatrix) - target.as(SHAInet::SimpleMatrix)
          end
   layer.backward(diff)
-  layer.apply_gradients(0.05, 0.0)
+  layer.apply_gradients(0.05_f32, 0.0_f32)
 end
 
 puts "Output after training:"


### PR DESCRIPTION
## Summary
- use `Float32` literals in example data and parameters
- ensure code compiles

## Testing
- `crystal build examples/llm_sample.cr -o /tmp/llm_sample`
- `crystal build examples/quantize_int8.cr -o /tmp/qint8`
- `crystal build examples/transformer_lm.cr -o /tmp/transformer_lm`
- `crystal build examples/transformer_pe.cr -o /tmp/transformer_pe`
- `crystal build examples/babylm_transformer.cr -o /tmp/baby`


------
https://chatgpt.com/codex/tasks/task_e_68752e4bab1c833198df3bfb6c83cbef