### PR TITLE
Add FP16/BF16 GPU loss kernels

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -707,7 +707,7 @@ module SHAInet
           raise NeuralNetRunError.new("Label #{label} out of bounds for output size #{logits.cols}")
         end
 
-        target = CudaMatrix.zeros(1, logits.cols)
+        target = CudaMatrix.zeros(1, logits.cols, precision: @precision)
         target[0, label] = 1.0_f32
         target.sync_to_device!
 
@@ -776,7 +776,7 @@ module SHAInet
           raise NeuralNetRunError.new("Label #{label} out of bounds for output size #{logits.cols}")
         end
 
-        target = CudaMatrix.zeros(1, logits.cols)
+        target = CudaMatrix.zeros(1, logits.cols, precision: @precision)
         target[0, label] = 1.0_f32
         target.sync_to_device!
 

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -701,6 +701,36 @@ module SHAInet
         raise "CUDA cross_entropy_loss_and_gradient failed" if result != 0
         grad_output.mark_device_dirty!
         return
+      elsif CUDA.available? && predicted.precision.fp16? && target.precision.fp16? && grad_output.precision.fp16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.cross_entropy_loss_gradient_fp16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          loss_output,
+          predicted.rows,
+          predicted.cols
+        )
+        raise "CUDA cross_entropy_loss_and_gradient failed" if result != 0
+        grad_output.mark_device_dirty!
+        return
+      elsif CUDA.available? && predicted.precision.bf16? && target.precision.bf16? && grad_output.precision.bf16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.cross_entropy_loss_gradient_bf16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          loss_output,
+          predicted.rows,
+          predicted.cols
+        )
+        raise "CUDA cross_entropy_loss_and_gradient failed" if result != 0
+        grad_output.mark_device_dirty!
+        return
       end
 
       predicted.sync_from_device!("cross_entropy_pred") if predicted.device_dirty?
@@ -739,6 +769,30 @@ module SHAInet
           predicted.rows,
           predicted.cols
         )
+      elsif predicted.precision.fp16? && target.precision.fp16? && grad_output.precision.fp16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.mse_cost_gradient_fp16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          loss_output,
+          predicted.rows,
+          predicted.cols
+        )
+      elsif predicted.precision.bf16? && target.precision.bf16? && grad_output.precision.bf16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.mse_cost_gradient_bf16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          loss_output,
+          predicted.rows,
+          predicted.cols
+        )
       else
         raise ArgumentError.new("mse_loss_and_gradient only supports Fp32 precision")
       end
@@ -766,6 +820,34 @@ module SHAInet
           predicted.device_ptr.not_nil!.as(Pointer(Float32)),
           target.device_ptr.not_nil!.as(Pointer(Float32)),
           grad_output.device_ptr.not_nil!.as(Pointer(Float32)),
+          loss,
+          predicted.rows,
+          predicted.cols
+        )
+        raise "CUDA softmax_cross_entropy_loss_and_gradient failed" if result != 0
+        grad_output.mark_device_dirty!
+      elsif CUDA.available? && predicted.precision.fp16? && target.precision.fp16? && grad_output.precision.fp16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.softmax_cross_entropy_label_matrix_fp16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          loss,
+          predicted.rows,
+          predicted.cols
+        )
+        raise "CUDA softmax_cross_entropy_loss_and_gradient failed" if result != 0
+        grad_output.mark_device_dirty!
+      elsif CUDA.available? && predicted.precision.bf16? && target.precision.bf16? && grad_output.precision.bf16?
+        predicted.sync_to_device! unless predicted.device_dirty?
+        target.sync_to_device! unless target.device_dirty?
+        grad_output.sync_to_device! unless grad_output.device_dirty?
+        result = CUDA.softmax_cross_entropy_label_matrix_bf16(
+          predicted.device_ptr.not_nil!.as(UInt16Ptr),
+          target.device_ptr.not_nil!.as(UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
           loss,
           predicted.rows,
           predicted.cols

--- a/src/shainet/native/cuda_kernels.cu
+++ b/src/shainet/native/cuda_kernels.cu
@@ -1254,6 +1254,18 @@ void cross_entropy_loss_gradient_f32(float *pred, float *target, float *grad,
   cross_entropy_loss_gradient_t<float>(pred, target, grad, loss, rows, cols);
 }
 
+void cross_entropy_loss_gradient_fp16(__half *pred, __half *target, __half *grad,
+                                      float *loss, int rows, int cols) {
+  cross_entropy_loss_gradient_t<__half>(pred, target, grad, loss, rows, cols);
+}
+
+void cross_entropy_loss_gradient_bf16(__nv_bfloat16 *pred, const __nv_bfloat16 *target,
+                                      __nv_bfloat16 *grad, float *loss, int rows,
+                                      int cols) {
+  cross_entropy_loss_gradient_t<__nv_bfloat16>(pred, target, grad, loss, rows,
+                                               cols);
+}
+
 void softmax_cross_entropy_label(float *pred, const int *labels, float *grad,
                                  float *loss, int rows, int cols) {
   softmax_cross_entropy_label_t<float>(pred, labels, grad, loss, rows, cols);
@@ -1279,6 +1291,21 @@ void softmax_cross_entropy_label_matrix_f32(float *pred, const float *labels,
                                               cols);
 }
 
+void softmax_cross_entropy_label_matrix_fp16(const __half *pred,
+                                             const __half *labels, __half *grad,
+                                             float *loss, int rows, int cols) {
+  softmax_cross_entropy_label_matrix_t<__half>(pred, labels, grad, loss, rows,
+                                               cols);
+}
+
+void softmax_cross_entropy_label_matrix_bf16(const __nv_bfloat16 *pred,
+                                             const __nv_bfloat16 *labels,
+                                             __nv_bfloat16 *grad, float *loss,
+                                             int rows, int cols) {
+  softmax_cross_entropy_label_matrix_t<__nv_bfloat16>(pred, labels, grad, loss,
+                                                      rows, cols);
+}
+
 void mse_loss_gradient(float *pred, float *target, float *grad, float *loss,
                        int rows, int cols) {
   mse_loss_gradient_t<float>(pred, target, grad, loss, rows, cols);
@@ -1287,6 +1314,17 @@ void mse_loss_gradient(float *pred, float *target, float *grad, float *loss,
 void mse_loss_gradient_f32(float *pred, float *target, float *grad,
                            float *loss, int rows, int cols) {
   mse_loss_gradient_t<float>(pred, target, grad, loss, rows, cols);
+}
+
+void mse_loss_gradient_fp16(const __half *pred, const __half *target,
+                            __half *grad, float *loss, int rows, int cols) {
+  mse_loss_gradient_t<__half>(pred, target, grad, loss, rows, cols);
+}
+
+void mse_loss_gradient_bf16(const __nv_bfloat16 *pred, const __nv_bfloat16 *target,
+                            __nv_bfloat16 *grad, float *loss, int rows,
+                            int cols) {
+  mse_loss_gradient_t<__nv_bfloat16>(pred, target, grad, loss, rows, cols);
 }
 
 } // extern "C"


### PR DESCRIPTION
## Summary
- add FP16/BF16 variants of loss kernels in native CUDA implementation
- expose new CUDA functions in `CUDA` module
- extend cuDNN helpers to call kernels for FP16/BF16
- ensure evaluation helpers create targets using network precision

## Testing
- `crystal spec spec/softmax_cross_entropy_cuda_spec.cr --no-color`

------
https://chatgpt.com/codex/tasks/task_e_687547c1a6e0833180a50e9a53da3f44