### PR TITLE
Fix mask validation in transformer and update babylm example

### DIFF
--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -41,8 +41,10 @@ transformer_layers = 4
 # epochs: Number of training epochs.
 # Larger epochs will take longer but may improve performance.
 epochs = 100
-# batch: Batch size for training. Larger sizes can improve GPU utilization.
-batch = 4000
+# batch: Batch size for training.
+# For transformer models the mask is shared across the batch, so
+# using batches > 1 will trigger a mask size mismatch.
+batch = 1
 # Learning rate for the AdamW optimizer.
 # A smaller learning rate can help with stability, especially for larger models.
 learning_rate = 0.0005_f32

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -219,6 +219,9 @@ module SHAInet
     # GPU path - all operations with CudaMatrix - optimized with workspace pool
     def forward(x : CudaMatrix, mask : CudaMatrix | Nil = nil, rotary_freqs : CudaMatrix | Nil = nil) : CudaMatrix
       @x = x
+      if mask && (mask.rows != x.rows || mask.cols != x.rows)
+        raise ArgumentError.new("mask size mismatch: input is #{x.rows}x#{x.rows}, mask is #{mask.rows}x#{mask.cols}")
+      end
 
       # Ensure workspace matrices are allocated for this batch size
       ensure_workspace_matrices(x.rows)
@@ -325,6 +328,9 @@ module SHAInet
 
     # GPU path with KV caching. Returns a tuple of the output and updated cache.
     def forward(x : CudaMatrix, mask : CudaMatrix | Nil, cache : KVCache, layer : Int32, rotary_freqs : CudaMatrix | Nil = nil) : Tuple(CudaMatrix, KVCache)
+      if mask && (mask.rows != x.rows || mask.cols != x.rows)
+        raise ArgumentError.new("mask size mismatch: input is #{x.rows}x#{x.rows}, mask is #{mask.rows}x#{mask.cols}")
+      end
       # Compute fresh projections for the new step
       q = x * @w_q.as(CudaMatrix)
       k_proj = x * @w_k.as(CudaMatrix)
@@ -378,6 +384,9 @@ module SHAInet
     # CPU path - all operations with SimpleMatrix
     def forward(x : SimpleMatrix, mask : SimpleMatrix | Nil = nil, rotary_freqs : SimpleMatrix | Nil = nil) : SimpleMatrix
       @x = x
+      if mask && (mask.rows != x.rows || mask.cols != x.rows)
+        raise ArgumentError.new("mask size mismatch: input is #{x.rows}x#{x.rows}, mask is #{mask.rows}x#{mask.cols}")
+      end
 
       # Compute Q, K, V projections - CPU path
       q = x * @w_q.as(SimpleMatrix)
@@ -435,6 +444,9 @@ module SHAInet
 
     # CPU path with KV caching. Returns a tuple of the output and updated cache.
     def forward(x : SimpleMatrix, mask : SimpleMatrix | Nil, cache : KVCache, layer : Int32, rotary_freqs : SimpleMatrix | Nil = nil) : Tuple(SimpleMatrix, KVCache)
+      if mask && (mask.rows != x.rows || mask.cols != x.rows)
+        raise ArgumentError.new("mask size mismatch: input is #{x.rows}x#{x.rows}, mask is #{mask.rows}x#{mask.cols}")
+      end
       q = x * @w_q.as(SimpleMatrix)
       k_proj = x * @w_k.as(SimpleMatrix)
       v_proj = x * @w_v.as(SimpleMatrix)


### PR DESCRIPTION
## Summary
- avoid extremely large allocations in multi-head attention by checking mask size against the input
- clarify that batched training isn't supported in `babylm_transformer` and set batch size to 1

## Testing
- `crystal build src/shainet.cr -o /tmp/shainet.o`
- `crystal spec spec/accumulation_spec.cr -v`
- `crystal spec --order random` *(fails: Stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_687559a07ff8833198bf0d3415dcb6cb