### PR TITLE
Allow GPU pool limit via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ To build kernels manually:
 ./build_cuda_kernels.sh
 ```
 
+You can control how many GPU buffers are cached by setting the
+`SHAINET_GPU_POOL_LIMIT` environment variable before running your program.
+The default limit is 16 cached buffers.
+
+```bash
+SHAINET_GPU_POOL_LIMIT=32 crystal run my_train.cr
+```
+
 ### Device management
 
 Layers such as `LayerNorm` allocate workspace matrices on the first forward pass

--- a/src/shainet/math/gpu_memory.cr
+++ b/src/shainet/math/gpu_memory.cr
@@ -11,7 +11,8 @@ module SHAInet
 
     # -- Simple GPU allocator -------------------------------------------------
     @@pool = Hash(Int32, Array(Pointer(Float32))).new { |h, k| h[k] = [] of Pointer(Float32) }
-    @@pool_limit : Int32 = 2 # Very small pool to reduce memory pressure
+    @@pool_limit : Int32 = (ENV["SHAINET_GPU_POOL_LIMIT"]? || "16").to_i
+    # Default number of cached buffers (can be overridden via SHAINET_GPU_POOL_LIMIT)
 
     # Debug counter to track active GPU allocations
     @@active_allocations = 0


### PR DESCRIPTION
## Summary
- increase default GPU memory pool to 16 cached buffers
- let `SHAINET_GPU_POOL_LIMIT` override the pool limit
- document GPU pool limit environment variable in README

## Testing
- `crystal spec` *(fails: stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_68755b9d9a5c8331a17c7140355f7e28