### PR TITLE
Improve GPU matrix copy speed

### DIFF
--- a/src/shainet/math/simple_matrix.cr
+++ b/src/shainet/math/simple_matrix.cr
@@ -465,11 +465,7 @@ module SHAInet
     # Convert SimpleMatrix to CudaMatrix for GPU operations
     def to_cuda : CudaMatrix
       result = CudaMatrix.new(@rows, @cols, precision: @precision, device_id: CUDA.current_device || 0)
-      dest_buf = result.raw_data_buffer
-      src_buf = raw_data_buffer
-      dest_buf.copy_from(src_buf)
-      result.mark_device_dirty!
-      result.sync_to_device!("simple_to_cuda_conversion")
+      GPUMemory.to_gpu!(self, result)
       result
     end
 


### PR DESCRIPTION
## Summary
- optimize `GPUMemory.to_gpu!` to use `CUDA.memcpy`
- reuse new helper from `SimpleMatrix#to_cuda`

## Testing
- `crystal spec spec/gpu_memory_fp16_copy_spec.cr`
- `crystal spec --order=random` *(fails: Stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_68755b68d3cc8331a4d4aa72f7fa0c9f