### PR TITLE
Add missing CPU fallback warnings

### DIFF
--- a/src/shainet/basic/matrix_layer.cr
+++ b/src/shainet/basic/matrix_layer.cr
@@ -214,6 +214,7 @@ module SHAInet
         @sigma_primes.as(CudaMatrix).mark_device_dirty!
       else
         # For other activation functions, fall back to CPU
+        Log.warn { "Falling back to CPU for activation function" }
         linear_result.rows.times do |i|
           linear_result.cols.times do |j|
             val = linear_result[i, j]

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -624,6 +624,7 @@ module SHAInet
     def self.element_mul!(result : CudaMatrix, a : CudaMatrix, b : CudaMatrix, alpha : Float32 = 1.0, beta : Float32 = 0.0)
       # Element-wise multiplication requires custom implementation since cuBLAS doesn't have direct support
       # For now, fall back to CPU implementation
+      Log.warn { "Falling back to CPU for element_mul" }
       raise "Matrices must have same dimensions" unless a.rows == b.rows && a.cols == b.cols && result.rows == a.rows && result.cols == a.cols
 
       # Sync to CPU for element-wise operations

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1409,6 +1409,7 @@ module SHAInet
           result.mark_device_dirty!
         else
           # GPU not used - fall back to CPU
+          Log.warn { "Falling back to CPU for element_division" }
           self.sync_from_device!("element_division")
           other.sync_from_device!("element_division")
           @rows.times do |i|
@@ -1422,6 +1423,7 @@ module SHAInet
         end
       else
         # Fallback to CPU implementation
+        Log.warn { "Falling back to CPU for element_division" }
         self.sync_from_device!("element_division") if device_dirty?
         other.sync_from_device!("element_division") if other.device_dirty?
 

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -126,6 +126,7 @@ module SHAInet
           return result
         rescue
           # If CUDA operations fail, fall back to CPU then convert
+          Log.warn { "Falling back to CPU for embedding lookup" }
           return embed_cpu(ids).to_cuda
         end
       end


### PR DESCRIPTION
## Summary
- warn when embedding falls back to CPU
- log CPU fallback for element division
- add warning for cudnn element multiply fallback
- warn on CPU fallback for activation functions

## Testing
- `crystal spec` *(fails: Stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_68755b7f91208331960cec2c481dea7d