### PR TITLE
Fix BFloat16 recursion

### DIFF
--- a/src/shainet/float16.cr
+++ b/src/shainet/float16.cr
@@ -37,19 +37,13 @@ module SHAInet
       ((@bits.to_u32) << 16).unsafe_as(Float32)
     end
 
-    def to_f32 : Float32
+    def to_f : Float32
       to_f32
     end
   end
 end
 
 # Convenience conversion helpers
-struct Float32
-  def to_f16 : SHAInet::Float16
-    SHAInet::Float16.new(self)
-  end
-end
-
 struct Float32
   def to_f16 : SHAInet::Float16
     SHAInet::Float16.new(self)


### PR DESCRIPTION
## Summary
- fix BFloat16 `to_f32` recursion
- remove duplicate helper definition

## Testing
- `crystal spec` *(fails: 4 examples)*

------
https://chatgpt.com/codex/tasks/task_e_6875eb01ccdc8331b3e31b0ee94f1fe1