### PR TITLE
Add configurable prefetch workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ stream = SHAInet::StreamingData.new(
   "data.txt",
   shuffle: true,
   chunk_size: 1024,
-  gpu_batches: true)
+  gpu_batches: true,
+  prefetch_workers: 2)
 
 net = SHAInet::Network.new
 net.add_layer(:input, 2, :memory, SHAInet.sigmoid)

--- a/spec/streaming_data_spec.cr
+++ b/spec/streaming_data_spec.cr
@@ -19,6 +19,19 @@ describe SHAInet::StreamingData do
     batch2.size.should eq(2)
   end
 
+  it "prefetches with multiple workers" do
+    File.open("/tmp/stream_multi.txt", "w") do |f|
+      4.times do |i|
+        f.puts "[[#{i},#{i}],[#{i % 2}]]"
+      end
+    end
+
+    data = SHAInet::StreamingData.new("/tmp/stream_multi.txt", prefetch_workers: 2)
+    batch = data.next_batch(2)
+    batch.size.should eq(2)
+    data.rewind
+  end
+
   it "reads tokenized data and reshuffles each epoch" do
     Random::DEFAULT.new_seed(42_u64, 13_u64)
     File.open("/tmp/stream_tok.txt", "w") do |f|


### PR DESCRIPTION
## Summary
- allow multiple loader fibers for `StreamingData` via `prefetch_workers`
- spawn the configured number of fibers in `start_prefetch`
- adjust queue size and worker shutdown logic
- document the new option in README
- test multi‑worker prefetching

## Testing
- `crystal spec --order random` *(fails: Expected 0.8674951 to be within 1.0e-6 of 0.8791685, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6876198768d88331a77b4e86b4e32acf