### PR TITLE
Add async CUDA streams support

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -40,6 +40,7 @@ module SHAInet
     # Alias used by GPU kernels when CUDA is enabled.
     # Defined here as a noop pointer type for compatibility
     alias UInt16Ptr = Pointer(UInt16)
+    alias Stream = Void*
 
     enum MemcpyKind
       HostToHost     = 0
@@ -158,6 +159,17 @@ module SHAInet
       0
     end
 
+    def memcpy_async(*args) : Int32
+      0
+    end
+
+    def stream_create : Stream
+      Pointer(Void).null
+    end
+
+    def stream_synchronize(stream : Stream)
+    end
+
     def copy_device_to_device(dst : Pointer(Void), src : Pointer(Void), bytes : LibC::SizeT) : Int32
       # no-op when CUDA is disabled
       0
@@ -183,6 +195,13 @@ module SHAInet
     end
 
     def destroy_handle(*args)
+    end
+
+    def set_handle_stream(*args)
+    end
+
+    def get_handle_stream(*args)
+      Pointer(Void).null
     end
 
     def cleanup_handles(*args)

--- a/src/shainet/cudnn.cr
+++ b/src/shainet/cudnn.cr
@@ -667,13 +667,13 @@ module SHAInet
       predicted.sync_from_device!("xent_pred") if predicted.device_dirty?
       target.sync_from_device!("xent_target") if target.device_dirty?
 
-      loss = 0.0
+      loss = 0.0_f32
       predicted.rows.times do |i|
         predicted.cols.times do |j|
-          p = predicted.unsafe_get(i, j).to_f32.clamp(1e-15, 1.0)
+          p = predicted.unsafe_get(i, j).to_f32.clamp(1e-15_f32, 1.0_f32)
           t = target.unsafe_get(i, j).to_f32
           grad_output.unsafe_set(i, j, p - t)
-          loss += -t * Math.log(p)
+          loss += -t * Math.log(p).to_f32
         end
       end
 
@@ -707,9 +707,9 @@ module SHAInet
         target.sync_to_device! unless target.device_dirty?
         grad_output.sync_to_device! unless grad_output.device_dirty?
         result = CUDA.cross_entropy_loss_gradient_fp16(
-          predicted.device_ptr.not_nil!.as(UInt16Ptr),
-          target.device_ptr.not_nil!.as(UInt16Ptr),
-          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          predicted.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
+          target.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
           loss_output,
           predicted.rows,
           predicted.cols
@@ -722,9 +722,9 @@ module SHAInet
         target.sync_to_device! unless target.device_dirty?
         grad_output.sync_to_device! unless grad_output.device_dirty?
         result = CUDA.cross_entropy_loss_gradient_bf16(
-          predicted.device_ptr.not_nil!.as(UInt16Ptr),
-          target.device_ptr.not_nil!.as(UInt16Ptr),
-          grad_output.device_ptr.not_nil!.as(UInt16Ptr),
+          predicted.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
+          target.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
+          grad_output.device_ptr.not_nil!.as(CUDA::UInt16Ptr),
           loss_output,
           predicted.rows,
           predicted.cols
@@ -737,13 +737,13 @@ module SHAInet
       predicted.sync_from_device!("cross_entropy_pred") if predicted.device_dirty?
       target.sync_from_device!("cross_entropy_target") if target.device_dirty?
 
-      loss = 0.0
+      loss = 0.0_f32
       predicted.rows.times do |i|
         predicted.cols.times do |j|
-          p = predicted.unsafe_get(i, j).to_f32.clamp(1e-15, 1.0)
+          p = predicted.unsafe_get(i, j).to_f32.clamp(1e-15_f32, 1.0_f32)
           t = target.unsafe_get(i, j).to_f32
           grad_output.unsafe_set(i, j, p - t)
-          loss += -t * Math.log(p)
+          loss += -t * Math.log(p).to_f32
         end
       end
 

--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -81,7 +81,7 @@ module SHAInet
     def dropout(drop_percent : Int32)
       raise ArgumentError.new("drop_percent must be between 0 and 100") unless 0 <= drop_percent <= 100
       result = CudaMatrix.new(@rows, @cols, 0.0, @precision)
-      prob = drop_percent.to_f / 100.0
+      prob = drop_percent.to_f32 / 100.0_f32
       if CUDA.fully_available? && (dptr = self.device_ptr) && !dptr.null? && (rptr = result.device_ptr) && !rptr.null?
         seed = Random.rand(UInt64)
         begin


### PR DESCRIPTION
## Summary
- expose CUDA stream bindings and stream helpers
- allow setting cublas handle streams
- add async memory copy helpers
- wire optional stream parameter through GPU memory utilities and matrix sync
- fix type issues uncovered during build

## Testing
- `shards install`
- `crystal spec` *(fails: 4 examples, PyTorch missing)*

------
https://chatgpt.com/codex/tasks/task_e_687619d0bfb4833196a31fd90038fd41