### PR TITLE
Fix precision handling in safe_output_transform

### DIFF
--- a/spec/safe_output_transform_spec.cr
+++ b/spec/safe_output_transform_spec.cr
@@ -82,4 +82,33 @@ describe "safe_output_transform" do
       net.call_safe_output_transform(input, weights)
     end
   end
+
+  it "works when network precision is Fp16 and input is Fp32" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    net = SHAInet::Network.new
+    net.precision = SHAInet::Precision::Fp16
+    net.hidden_layers << SHAInet::TransformerBlock.new(2, 1, 2)
+
+    input = SHAInet::CudaMatrix.new(2, 2, precision: SHAInet::Precision::Fp32)
+    weights = SHAInet::CudaMatrix.new(2, 1, precision: SHAInet::Precision::Fp16)
+
+    2.times do |i|
+      2.times do |j|
+        input[i, j] = (i * 2 + j + 1).to_f32
+      end
+    end
+    weights[0, 0] = 1.0_f32
+    weights[1, 0] = 2.0_f32
+
+    input.sync_to_device!
+    weights.sync_to_device!
+
+    output = net.call_safe_output_transform(input, weights)
+    output.sync_from_device!
+
+    output.rows.should eq 1
+    output.cols.should eq 1
+    output[0, 0].should be_close(input[1, 0]*1.0_f32 + input[1, 1]*2.0_f32, 1e-3_f32)
+  end
 end

--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1477,7 +1477,7 @@ module SHAInet
                          if mptr && wptr && !mptr.null? && !wptr.null?
                            begin
                              CUDA.set_device(matrix.device_id)
-                             result = CudaMatrix.new(1, matrix.cols, precision: @precision, device_id: matrix.device_id)
+                             result = CudaMatrix.new(1, matrix.cols, precision: matrix.precision, device_id: matrix.device_id)
                              last_row_offset = (matrix.rows - 1) * matrix.cols
                              elem_size = matrix.element_size
                              byte_offset = last_row_offset * elem_size
@@ -1500,7 +1500,7 @@ module SHAInet
                                  slice_rows_helper(matrix, matrix.rows - 1, 1)
                                else
                                  result.mark_device_dirty!
-                                 result
+                                 convert_matrix_precision(result, @precision)
                                end
                              end
                            rescue e
@@ -1513,12 +1513,12 @@ module SHAInet
                          end
                        else
                          # CPU fallback
-                         last_token_cpu = CudaMatrix.new(1, matrix.cols, precision: @precision, device_id: matrix.device_id)
+                         last_token_cpu = CudaMatrix.new(1, matrix.cols, precision: matrix.precision, device_id: matrix.device_id)
                          matrix.cols.times do |j|
                            last_token_cpu[0, j] = matrix[matrix.rows - 1, j]
                          end
                          last_token_cpu.sync_to_device!
-                         last_token_cpu
+                         convert_matrix_precision(last_token_cpu, @precision)
                        end
 
           # Now multiply: last_token (1 x d_model) * weights (d_model x vocab_size)
@@ -1684,6 +1684,19 @@ module SHAInet
       num_rows.times do |i|
         matrix.cols.times do |j|
           result[i, j] = matrix[start_row + i, j]
+        end
+      end
+      result.sync_to_device! if CUDA.fully_available?
+      result
+    end
+
+    private def convert_matrix_precision(mat : CudaMatrix, prec : Precision) : CudaMatrix
+      return mat if mat.precision == prec
+      mat.sync_from_device!("convert_matrix_precision") if mat.device_dirty?
+      result = CudaMatrix.new(mat.rows, mat.cols, precision: prec, device_id: mat.device_id)
+      mat.rows.times do |i|
+        mat.cols.times do |j|
+          result[i, j] = mat[i, j]
         end
       end
       result.sync_to_device! if CUDA.fully_available?


### PR DESCRIPTION
## Summary
- ensure `safe_output_transform` respects input matrix precision
- convert intermediate row to network precision when needed
- cover mixed precision case in `safe_output_transform_spec`

## Testing
- `crystal spec spec/safe_output_transform_spec.cr -v`


------
https://chatgpt.com/codex/tasks/task_e_68761ca36b788331b02c36ee26c9d3c0