### PR TITLE
Support precision option for transformer & embedding layers

### DIFF
--- a/spec/layer_precision_spec.cr
+++ b/spec/layer_precision_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+
+describe "Layer precision propagation" do
+  it "applies network precision to embedding and transformer layers" do
+    net = SHAInet::Network.new
+    net.precision = SHAInet::Precision::Fp16
+    net.add_layer(:input, 1)
+    net.add_layer(:embedding, 4, SHAInet.none, vocab_size: 5)
+    net.add_layer(:transformer, 4)
+    net.add_layer(:output, 1, SHAInet.none)
+    net.fully_connect
+
+    (net.input_layers + net.hidden_layers + net.output_layers).each do |l|
+      l.precision.should eq(SHAInet::Precision::Fp16)
+    end
+
+    emb = net.hidden_layers.find(&.is_a?(SHAInet::EmbeddingLayer)).as(SHAInet::EmbeddingLayer)
+    emb.embeddings.precision.should eq(SHAInet::Precision::Fp16)
+
+    t_layer = net.transformer_layers.first
+    t_layer.mha.w_q.precision.should eq(SHAInet::Precision::Fp16)
+    t_layer.ffn.w1.precision.should eq(SHAInet::Precision::Fp16)
+    t_layer.norm1.gamma.precision.should eq(SHAInet::Precision::Fp16)
+    t_layer.norm2.gamma.precision.should eq(SHAInet::Precision::Fp16)
+  end
+end

--- a/src/shainet/basic/network_setup.cr
+++ b/src/shainet/basic/network_setup.cr
@@ -117,9 +117,9 @@ module SHAInet
       layer = case l_type.to_s
               when "embedding"
                 raise NeuralNetRunError.new("vocab_size required for embedding layer") if vocab_size <= 0
-                EmbeddingLayer.new(vocab_size, l_size, activation_function)
+                EmbeddingLayer.new(vocab_size, l_size, activation_function, precision: @precision)
               when "transformer"
-                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent, pre_norm, activation_function)
+                TransformerLayer.new(l_size, num_heads, ff_hidden, drop_percent, pre_norm, activation_function, precision: @precision)
               else
                 # Use MatrixLayer for regular feedforward layers - it has proper GPU support and gradient computation
                 # Note: MatrixLayer will be properly connected with correct input size in connect_ltl

--- a/src/shainet/text/embedding_layer.cr
+++ b/src/shainet/text/embedding_layer.cr
@@ -14,17 +14,17 @@ module SHAInet
     @workspace_result : CudaMatrix | Nil
     @last_ids_size : Int32
 
-    def initialize(vocab_size : Int32, l_size : Int32, activation_function : ActivationFunction = SHAInet.none)
-      super(l_size, activation_function)
+    def initialize(vocab_size : Int32, l_size : Int32, activation_function : ActivationFunction = SHAInet.none, *, precision : Precision = Precision::Fp32)
+      super(l_size, activation_function, precision: precision)
       mat_klass = CUDA.fully_available? ? CudaMatrix : SimpleMatrix
       # Initialize with random values between -0.1 and 0.1
-      @embeddings = mat_klass.new(vocab_size, l_size)
+      @embeddings = mat_klass.new(vocab_size, l_size, 0.0_f32, precision)
       vocab_size.times do |r|
         l_size.times do |c|
           @embeddings[r, c] = rand(-0.1..0.1).to_f32
         end
       end
-      @gradients = mat_klass.zeros(vocab_size, l_size)
+      @gradients = mat_klass.zeros(vocab_size, l_size, precision)
       @current_ids = [] of Int32
 
       @q_embeddings = nil

--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -36,18 +36,21 @@ module SHAInet
     # devices. Repeated calls without a device change keep the existing
     # workspaces to avoid unnecessary allocations.
 
-    def initialize(d_model : Int32, epsilon : Float32 = 1e-5)
+    property precision : Precision
+
+    def initialize(d_model : Int32, epsilon : Float32 = 1e-5, *, precision : Precision = Precision::Fp32)
+      @precision = precision
       # Use CudaMatrix when CUDA is available for better performance
       mat_klass = CUDA.fully_available? ? CudaMatrix : SimpleMatrix
-      @gamma = mat_klass.new(1, d_model)
+      @gamma = mat_klass.new(1, d_model, 0.0_f32, precision)
       d_model.times { |j| @gamma[0, j] = 1.0 }
-      @beta = mat_klass.zeros(1, d_model)
-      @g_gamma = mat_klass.zeros(1, d_model)
-      @g_beta = mat_klass.zeros(1, d_model)
+      @beta = mat_klass.zeros(1, d_model, precision)
+      @g_gamma = mat_klass.zeros(1, d_model, precision)
+      @g_beta = mat_klass.zeros(1, d_model, precision)
       @epsilon = epsilon
-      @mean = mat_klass.zeros(1, 1)
-      @var = mat_klass.zeros(1, 1)
-      @norm = mat_klass.zeros(1, 1)
+      @mean = mat_klass.zeros(1, 1, precision)
+      @var = mat_klass.zeros(1, 1, precision)
+      @norm = mat_klass.zeros(1, 1, precision)
       @d_model = d_model
       @last_batch_size = 0
 

--- a/src/shainet/transformer/multi_head_attention.cr
+++ b/src/shainet/transformer/multi_head_attention.cr
@@ -86,22 +86,25 @@ module SHAInet
     getter w_q, w_k, w_v, w_o
     property g_w_q, g_w_k, g_w_v, g_w_o
 
-    def initialize(@d_model : Int32, @num_heads : Int32)
+    property precision : Precision
+
+    def initialize(@d_model : Int32, @num_heads : Int32, *, precision : Precision = Precision::Fp32)
+      @precision = precision
       @head_dim = (@d_model // @num_heads)
       # Use CudaMatrix when CUDA is available for better performance
       mat_klass = CUDA.fully_available? ? CudaMatrix : SimpleMatrix
 
       # Use consistent matrix type throughout - no more TensorMatrix mixing
-      @w_q = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_k = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_v = mat_klass.new(@d_model, @d_model).random_fill!
-      @w_o = mat_klass.new(@d_model, @d_model).random_fill!
+      @w_q = mat_klass.new(@d_model, @d_model, 0.0_f32, precision).random_fill!
+      @w_k = mat_klass.new(@d_model, @d_model, 0.0_f32, precision).random_fill!
+      @w_v = mat_klass.new(@d_model, @d_model, 0.0_f32, precision).random_fill!
+      @w_o = mat_klass.new(@d_model, @d_model, 0.0_f32, precision).random_fill!
 
       # Initialize gradients with same type as weights
-      @g_w_q = mat_klass.zeros(@d_model, @d_model)
-      @g_w_k = mat_klass.zeros(@d_model, @d_model)
-      @g_w_v = mat_klass.zeros(@d_model, @d_model)
-      @g_w_o = mat_klass.zeros(@d_model, @d_model)
+      @g_w_q = mat_klass.zeros(@d_model, @d_model, precision)
+      @g_w_k = mat_klass.zeros(@d_model, @d_model, precision)
+      @g_w_v = mat_klass.zeros(@d_model, @d_model, precision)
+      @g_w_o = mat_klass.zeros(@d_model, @d_model, precision)
 
       @q_heads = [] of (SimpleMatrix | CudaMatrix)
       @k_heads = [] of (SimpleMatrix | CudaMatrix)

--- a/src/shainet/transformer/transformer_block.cr
+++ b/src/shainet/transformer/transformer_block.cr
@@ -22,12 +22,13 @@ module SHAInet
 
     def initialize(d_model : Int32, num_heads : Int32, ff_hidden : Int32,
                    drop_percent : Int32 = 0, pre_norm : Bool = false,
-                   ff_activation : ActivationFunction = SHAInet.relu)
-      super(d_model, SHAInet.none)
-      @mha = MultiHeadAttention.new(d_model, num_heads)
-      @ffn = PositionWiseFF.new(d_model, ff_hidden, ff_activation)
-      @norm1 = LayerNorm.new(d_model)
-      @norm2 = LayerNorm.new(d_model)
+                   ff_activation : ActivationFunction = SHAInet.relu,
+                   *, precision : Precision = Precision::Fp32)
+      super(d_model, SHAInet.none, precision: precision)
+      @mha = MultiHeadAttention.new(d_model, num_heads, precision: precision)
+      @ffn = PositionWiseFF.new(d_model, ff_hidden, ff_activation, precision: precision)
+      @norm1 = LayerNorm.new(d_model, precision: precision)
+      @norm2 = LayerNorm.new(d_model, precision: precision)
       @positional_encoding = nil
       @drop_percent = drop_percent
       @pre_norm = pre_norm


### PR DESCRIPTION
## Summary
- pass network precision when adding embedding/transformer layers
- allow EmbeddingLayer, TransformerBlock, MultiHeadAttention, PositionWiseFF and LayerNorm to accept precision
- add spec verifying layers inherit network precision

## Testing
- `crystal spec spec/layer_precision_spec.cr`
- `crystal spec` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68761cb9e838833186ff1dddb543e97d