### PR TITLE
Enable async GPU batch transfers

### DIFF
--- a/src/shainet/basic/network_run.cr
+++ b/src/shainet/basic/network_run.cr
@@ -1212,15 +1212,17 @@ module SHAInet
         expected_parts << src_out
       end
 
+      stream = CUDA.fully_available? ? CUDA.stream_create : nil
+
       if input_matrix.is_a?(CudaMatrix)
-        GPUMemory.build_batch!(input_parts, input_matrix.as(CudaMatrix))
+        GPUMemory.build_batch!(input_parts, input_matrix.as(CudaMatrix), stream)
       else
         GPUMemory.build_batch!(input_parts, cpu_input)
         input_matrix = cpu_input
       end
 
       if expected_matrix.is_a?(CudaMatrix)
-        GPUMemory.build_batch!(expected_parts, expected_matrix.as(CudaMatrix))
+        GPUMemory.build_batch!(expected_parts, expected_matrix.as(CudaMatrix), stream)
       else
         GPUMemory.build_batch!(expected_parts, cpu_expected)
         expected_matrix = cpu_expected
@@ -1381,6 +1383,8 @@ module SHAInet
 
         @accumulation_counter = 0
       end
+
+      CUDA.stream_synchronize(stream) if stream
 
       @time_step += 1
       batch_error


### PR DESCRIPTION
## Summary
- support optional CUDA streams for `GPUMemory.to_gpu!`
- support optional CUDA streams for `GPUMemory.build_batch!`
- use a stream in `Network#process_batch` so host↔device transfers can overlap with computation

## Testing
- `shards install`
- `crystal spec` *(fails: 4 examples)*

------
https://chatgpt.com/codex/tasks/task_e_68762679cc448331bdcbfaca9d40d6fe