### PR TITLE
Add fp16/bf16 slice/set cols kernels

### DIFF
--- a/spec/cuda_slice_set_cols_fp16_spec.cr
+++ b/spec/cuda_slice_set_cols_fp16_spec.cr
@@ -1,0 +1,44 @@
+require "./spec_helper"
+
+describe "CudaMatrix slice/set cols FP16" do
+  it "slices columns for FP16 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    src = SHAInet::CudaMatrix.from_a([
+      [1.0_f32, 2.0_f32, 3.0_f32, 4.0_f32],
+      [5.0_f32, 6.0_f32, 7.0_f32, 8.0_f32],
+    ], SHAInet::Precision::Fp16)
+
+    dest = SHAInet::CudaMatrix.new(2, 2, precision: SHAInet::Precision::Fp16)
+
+    src.slice_cols_into!(dest, 1, 2)
+    dest.sync_from_device!
+
+    dest[0, 0].should be_close(2.0_f32, 1e-2_f32)
+    dest[0, 1].should be_close(3.0_f32, 1e-2_f32)
+    dest[1, 0].should be_close(6.0_f32, 1e-2_f32)
+    dest[1, 1].should be_close(7.0_f32, 1e-2_f32)
+  end
+
+  it "sets columns for FP16 precision" do
+    pending! "CUDA not available" unless SHAInet::CUDA.available?
+
+    dst = SHAInet::CudaMatrix.from_a([
+      [0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32],
+      [0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32],
+    ], SHAInet::Precision::Fp16)
+
+    src = SHAInet::CudaMatrix.from_a([
+      [9.0_f32, 8.0_f32],
+      [7.0_f32, 6.0_f32],
+    ], SHAInet::Precision::Fp16)
+
+    dst.set_cols!(1, src)
+    dst.sync_from_device!
+
+    dst[0, 1].should be_close(9.0_f32, 1e-2_f32)
+    dst[0, 2].should be_close(8.0_f32, 1e-2_f32)
+    dst[1, 1].should be_close(7.0_f32, 1e-2_f32)
+    dst[1, 2].should be_close(6.0_f32, 1e-2_f32)
+  end
+end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -715,7 +715,11 @@ module SHAInet
     @@gather_rows_fp16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(Int32), Int32, Int32, Void)? = nil
     @@gather_rows_bf16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Pointer(Int32), Int32, Int32, Void)? = nil
     @@slice_cols_proc : Proc(Pointer(Float32), Pointer(Float32), Int32, Int32, Int32, Int32, Void)? = nil
+    @@slice_cols_fp16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void)? = nil
+    @@slice_cols_bf16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void)? = nil
     @@set_cols_proc : Proc(Pointer(Float32), Pointer(Float32), Int32, Int32, Int32, Int32, Void)? = nil
+    @@set_cols_fp16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void)? = nil
+    @@set_cols_bf16_proc : Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void)? = nil
     @@row_mean_var_proc : Proc(Pointer(Float32), Pointer(Float32), Pointer(Float32), Int32, Int32, Void)? = nil
     @@row_mean_var_fp16_proc : Proc(Pointer(UInt16), Pointer(Float32), Pointer(Float32), Int32, Int32, Void)? = nil
     @@row_mean_var_bf16_proc : Proc(Pointer(UInt16), Pointer(Float32), Pointer(Float32), Int32, Int32, Void)? = nil
@@ -1094,6 +1098,40 @@ module SHAInet
       end
     end
 
+    def slice_cols_fp16(dst : Pointer(UInt16), src : Pointer(UInt16), rows : Int32, src_cols : Int32, start_col : Int32, len : Int32)
+      unless fn = @@slice_cols_fp16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "slice_cols_fp16")
+          unless sym.null?
+            @@slice_cols_fp16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@slice_cols_fp16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, src, rows, src_cols, start_col, len)
+    end
+
+    def slice_cols_bf16(dst : Pointer(UInt16), src : Pointer(UInt16), rows : Int32, src_cols : Int32, start_col : Int32, len : Int32)
+      unless fn = @@slice_cols_bf16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "slice_cols_bf16")
+          unless sym.null?
+            @@slice_cols_bf16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@slice_cols_bf16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, src, rows, src_cols, start_col, len)
+    end
+
     def set_cols(dst : Pointer(Float32), src : Pointer(Float32), rows : Int32, dst_cols : Int32, start_col : Int32, len : Int32)
       # Validate inputs
       if dst.null? || src.null? || rows <= 0 || dst_cols <= 0 || len <= 0 || start_col < 0 || (start_col + len) > dst_cols
@@ -1121,6 +1159,40 @@ module SHAInet
         Log.error { "CUDA Error in set_cols: #{e}" }
         raise e
       end
+    end
+
+    def set_cols_fp16(dst : Pointer(UInt16), src : Pointer(UInt16), rows : Int32, dst_cols : Int32, start_col : Int32, len : Int32)
+      unless fn = @@set_cols_fp16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "set_cols_fp16")
+          unless sym.null?
+            @@set_cols_fp16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@set_cols_fp16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, src, rows, dst_cols, start_col, len)
+    end
+
+    def set_cols_bf16(dst : Pointer(UInt16), src : Pointer(UInt16), rows : Int32, dst_cols : Int32, start_col : Int32, len : Int32)
+      unless fn = @@set_cols_bf16_proc
+        if @@kernels_handle.null?
+          @@kernels_handle = LibC.dlopen("libshainet_cuda_kernels.so", LibC::RTLD_LAZY)
+        end
+        unless @@kernels_handle.null?
+          sym = LibC.dlsym(@@kernels_handle, "set_cols_bf16")
+          unless sym.null?
+            @@set_cols_bf16_proc = Proc(Pointer(UInt16), Pointer(UInt16), Int32, Int32, Int32, Int32, Void).new(sym, Pointer(Void).null)
+            fn = @@set_cols_bf16_proc
+          end
+        end
+      end
+      raise "CUDA kernels not available" unless fn
+      fn.call(dst, src, rows, dst_cols, start_col, len)
     end
 
     def row_mean_var(src : Pointer(Float32), mean : Pointer(Float32), var : Pointer(Float32), rows : Int32, cols : Int32)

--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -321,7 +321,23 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def slice_cols_fp16(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def slice_cols_bf16(*args)
+      raise "CUDA kernels not available"
+    end
+
     def set_cols(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def set_cols_fp16(*args)
+      raise "CUDA kernels not available"
+    end
+
+    def set_cols_bf16(*args)
       raise "CUDA kernels not available"
     end
 

--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -509,10 +509,23 @@ module SHAInet
       # Ensure source data is on the GPU
       self.sync_to_device!("slice_cols_into") unless device_dirty?
 
-      CUDA.slice_cols(
-        dptr.as(Pointer(Float32)),
-        sptr.as(Pointer(Float32)),
-        @rows, @cols, start_col, length)
+      case @precision
+      when Precision::Fp16
+        CUDA.slice_cols_fp16(
+          dptr.as(CUDA::UInt16Ptr),
+          sptr.as(CUDA::UInt16Ptr),
+          @rows, @cols, start_col, length)
+      when Precision::Bf16
+        CUDA.slice_cols_bf16(
+          dptr.as(CUDA::UInt16Ptr),
+          sptr.as(CUDA::UInt16Ptr),
+          @rows, @cols, start_col, length)
+      else
+        CUDA.slice_cols(
+          dptr.as(Pointer(Float32)),
+          sptr.as(Pointer(Float32)),
+          @rows, @cols, start_col, length)
+      end
 
       dest.mark_device_dirty!
       dest
@@ -538,10 +551,23 @@ module SHAInet
       self.sync_to_device!("set_cols") unless device_dirty?
       other.sync_to_device!("set_cols") unless other.device_dirty?
 
-      CUDA.set_cols(
-        dptr.as(Pointer(Float32)),
-        sptr.as(Pointer(Float32)),
-        @rows, @cols, start_col, other.cols)
+      case @precision
+      when Precision::Fp16
+        CUDA.set_cols_fp16(
+          dptr.as(CUDA::UInt16Ptr),
+          sptr.as(CUDA::UInt16Ptr),
+          @rows, @cols, start_col, other.cols)
+      when Precision::Bf16
+        CUDA.set_cols_bf16(
+          dptr.as(CUDA::UInt16Ptr),
+          sptr.as(CUDA::UInt16Ptr),
+          @rows, @cols, start_col, other.cols)
+      else
+        CUDA.set_cols(
+          dptr.as(Pointer(Float32)),
+          sptr.as(Pointer(Float32)),
+          @rows, @cols, start_col, other.cols)
+      end
 
       # Mark self as having newer GPU data
       mark_device_dirty!


### PR DESCRIPTION
## Summary
- implement templated CUDA kernels for slicing/setting columns
- expose new fp16/bf16 kernel wrappers in CUDA module
- provide stub methods when CUDA disabled
- dispatch in `CudaMatrix` based on precision
- add fp16 spec for slicing and setting columns

## Testing
- `crystal tool format`
- `crystal spec --order random spec/cuda_slice_set_cols_fp16_spec.cr`
- `crystal spec --order random` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68765c32272083318bdcaeb9ab3a54e9