### PR TITLE
Fix LayerNorm CPU fallback

### DIFF
--- a/src/shainet/transformer/layer_norm.cr
+++ b/src/shainet/transformer/layer_norm.cr
@@ -331,7 +331,9 @@ module SHAInet
         end
       end
 
-      result = @norm.clone.as(CudaMatrix)
+      result = @norm.clone
+      result = result.to_cuda if result.is_a?(SimpleMatrix)
+      result = result.as(CudaMatrix)
       result.mul_row_vector!(@gamma.as(CudaMatrix))
       result.add_bias!(@beta.as(CudaMatrix))
       result


### PR DESCRIPTION
## Summary
- fix conversion when LayerNorm GPU path falls back to CPU

## Testing
- `crystal spec spec/layer_norm_cuda_parity_spec.cr --error-trace`
- `crystal eval 'require "./src/shainet"; puts "CUDA available: #{SHAInet::CUDA.available?}"; puts "CUDA kernels available: #{SHAInet::CUDA.kernels_available?}"; if SHAInet::CUDA.kernels_available?; puts "✓ GPU acceleration is ready!"; else; puts "✗ GPU acceleration not available. Run make cuda first."; end'`

------
https://chatgpt.com/codex/tasks/task_e_687748b051f8833181e0e10835eb7fd0