### PR TITLE
Fix precision pointer casts

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -520,11 +520,13 @@ module SHAInet
           dptr.as(CUDA::UInt16Ptr),
           sptr.as(CUDA::UInt16Ptr),
           @rows, @cols, start_col, length)
-      else
+      when Precision::Fp32
         CUDA.slice_cols(
           dptr.as(Pointer(Float32)),
           sptr.as(Pointer(Float32)),
           @rows, @cols, start_col, length)
+      else
+        raise "slice_cols_into! unsupported for precision #{@precision}"
       end
 
       dest.mark_device_dirty!
@@ -562,11 +564,13 @@ module SHAInet
           dptr.as(CUDA::UInt16Ptr),
           sptr.as(CUDA::UInt16Ptr),
           @rows, @cols, start_col, other.cols)
-      else
+      when Precision::Fp32
         CUDA.set_cols(
           dptr.as(Pointer(Float32)),
           sptr.as(Pointer(Float32)),
           @rows, @cols, start_col, other.cols)
+      else
+        raise "set_cols! unsupported for precision #{@precision}"
       end
 
       # Mark self as having newer GPU data
@@ -1549,10 +1553,7 @@ module SHAInet
               dptr.as(Pointer(Float32)),
               @rows, @cols)
           else
-            CUDA.softmax_rows(
-              dptr.as(Pointer(Float32)),
-              dptr.as(Pointer(Float32)),
-              @rows, @cols)
+            raise "softmax_rows! unsupported for precision #{@precision}"
           end
 
           mark_device_dirty!
@@ -1855,8 +1856,10 @@ module SHAInet
           else
             raise "axpyEx unavailable"
           end
-        else
+        when Precision::Int8
           CUDA.axpy(handle, -learning_rate, grad_ptr.as(Pointer(Float32)), weight_ptr.as(Pointer(Float32)), total_elements)
+        else
+          raise "weight_update! unsupported for precision #{@precision}"
         end
       rescue
         # CPU fallback when CUDA routines are missing
@@ -1907,7 +1910,7 @@ module SHAInet
           when Precision::Fp32
             CUDA.element_mul_fp32(sptr.as(Pointer(Float32)), sptr.as(Pointer(Float32)), optr.as(Pointer(Float32)), alpha, beta, size)
           else
-            CUDA.element_mul(sptr.as(Pointer(Float32)), sptr.as(Pointer(Float32)), optr.as(Pointer(Float32)), alpha, beta, size)
+            raise "element_mul! unsupported for precision #{@precision}"
           end
 
           mark_device_dirty!
@@ -1957,10 +1960,7 @@ module SHAInet
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)
           else
-            CUDA.dropout_fp32(
-              dptr.as(Pointer(Float32)),
-              dptr.as(Pointer(Float32)),
-              @rows, @cols, prob, seed)
+            raise "dropout! unsupported for precision #{@precision}"
           end
 
           mark_device_dirty!

--- a/src/shainet/math/cuda_matrix_ext.cr
+++ b/src/shainet/math/cuda_matrix_ext.cr
@@ -49,12 +49,7 @@ module SHAInet
               @cols
             )
           else
-            CUDA.softmax_rows(
-              rptr.as(Pointer(Float32)),
-              dptr.as(Pointer(Float32)),
-              @rows,
-              @cols
-            )
+            raise "Unsupported precision #{precision} for softmax_rows"
           end
 
           # Mark result as having newer GPU data
@@ -105,10 +100,7 @@ module SHAInet
               dptr.as(Pointer(Float32)),
               @rows, @cols, prob, seed)
           else
-            CUDA.dropout_fp32(
-              rptr.as(Pointer(Float32)),
-              dptr.as(Pointer(Float32)),
-              @rows, @cols, prob, seed)
+            raise "Unsupported precision #{precision} for dropout"
           end
 
           # Mark result as having newer GPU data


### PR DESCRIPTION
## Summary
- branch on `@precision` when launching CUDA kernels
- remove default FP32 fallbacks that hid unsupported precisions

## Testing
- `crystal spec --order random` *(fails: PyTorch not installed and several specs fail)*

------
https://chatgpt.com/codex/tasks/task_e_687766f1df5483319308983b77881894