### PR TITLE
Improve CUDA handle cleanup

### DIFF
--- a/spec/cuda_cleanup_spec.cr
+++ b/spec/cuda_cleanup_spec.cr
@@ -1,0 +1,22 @@
+require "./spec_helper"
+
+describe "CUDA.cleanup_handles" do
+  it "clears cuDNN handle" do
+    {% if flag?(:enable_cuda) %}
+      pending! "cuDNN not available" unless SHAInet::CUDNN.available?
+
+      a = SHAInet::CudaMatrix.new(1, 1, 1.0_f32, SHAInet::Precision::Fp16)
+      b = SHAInet::CudaMatrix.new(1, 1, 1.0_f32, SHAInet::Precision::Fp16)
+      result = SHAInet::CudaMatrix.new(1, 1, 0.0_f32, SHAInet::Precision::Fp16)
+
+      SHAInet::CUDNN.element_add!(result, a, b)
+      SHAInet::CUDNN.instance_variable_get(:"@@handle").should_not be_nil
+
+      SHAInet::CUDA.cleanup_handles
+
+      SHAInet::CUDNN.instance_variable_get(:"@@handle").should be_nil
+    {% else %}
+      pending! "CUDA not enabled"
+    {% end %}
+  end
+end

--- a/src/shainet/cuda.cr
+++ b/src/shainet/cuda.cr
@@ -505,6 +505,16 @@ module SHAInet
       end
       # Release persistent loss buffer
       free_loss_buffer
+
+      # Cleanup cuDNN resources when available
+      CUDNN.cleanup if CUDNN.responds_to?(:cleanup)
+      CUDNN.free_label_buffer if CUDNN.responds_to?(:free_label_buffer)
+
+      # Close optional CUDA kernels library
+      unless @@kernels_handle.null?
+        LibC.dlclose(@@kernels_handle)
+        @@kernels_handle = Pointer(Void).null
+      end
     end
 
     def gemm(handle : LibCUBLAS::Handle, a : Pointer(Float32), b : Pointer(Float32), c : Pointer(Float32),


### PR DESCRIPTION
## Summary
- extend `CUDA.cleanup_handles` to also release cuDNN resources and kernels handle
- add spec verifying cuDNN handle is cleared after cleanup

## Testing
- `crystal spec --order random` *(fails: 4 failing examples)*

------
https://chatgpt.com/codex/tasks/task_e_687769065d148331b0edc682b12afc9b