### PR TITLE
Fix gemm pointer initialization

### DIFF
--- a/src/shainet/math/cuda_matrix.cr
+++ b/src/shainet/math/cuda_matrix.cr
@@ -1764,7 +1764,10 @@ module SHAInet
             raise "axpyEx unavailable"
           end
         when Precision::Int8
-          CUDA.axpy(handle, -learning_rate, grad_ptr.as(Pointer(Float32)), weight_ptr.as(Pointer(Float32)), total_elements)
+          CUDA.axpy(handle, -learning_rate,
+            grad_ptr.as(Pointer(Void)),
+            weight_ptr.as(Pointer(Void)),
+            total_elements, Precision::Fp32)
         else
           raise "weight_update! unsupported for precision #{@precision}"
         end


### PR DESCRIPTION
## Summary
- avoid pointer reads of uninitialised alpha/beta variables in CUDA gemm
- fix missing precision arguments on CUDA axpy helpers

## Testing
- `crystal build examples/babylm_transformer.cr --release -Denable_cuda --error-trace` *(fails: instantiating network training later in build)*
- `crystal spec --order=random` *(fails: 4 examples)*

------
https://chatgpt.com/codex/tasks/task_e_68777a2fc5188331a55868788544d0f4