### PR TITLE
Support GER for FP16 and BF16

### DIFF
--- a/spec/embedding_accumulate_precision_spec.cr
+++ b/spec/embedding_accumulate_precision_spec.cr
@@ -1,0 +1,25 @@
+require "./spec_helper"
+
+describe "Embedding accumulate gradient precision" do
+  it "accumulates gradients for FP16 and BF16" do
+    pending! "CUDA kernels not available" unless SHAInet::CUDA.fully_available?
+
+    vocab = 4
+    dims = 3
+
+    {% if flag?(:enable_cuda) %}
+      {SHAInet::Precision::Fp16, SHAInet::Precision::Bf16}.each do |prec|
+        layer = SHAInet::EmbeddingLayer.new(vocab, dims, precision: prec)
+        layer.to_gpu!
+        layer.embed(1)
+        layer.accumulate_gradient
+        layer.gradients.as(SHAInet::CudaMatrix).sync_from_device!
+        dims.times do |i|
+          layer.gradients[1, i].to_f.should be_close(layer.activations.not_nil![0, i].to_f, 1e-2_f32)
+        end
+      end
+    {% else %}
+      pending! "CUDA not enabled"
+    {% end %}
+  end
+end


### PR DESCRIPTION
## Summary
- add dynamic CUDA helpers for GER in FP16/BF16
- implement matching kernels and wrappers
- dispatch embedding gradient accumulation based on matrix precision
- add regression test for half/bfloat16 accumulation

## Testing
- `crystal tool format src/shainet/cuda.cr src/shainet/text/embedding_layer.cr spec/embedding_accumulate_precision_spec.cr`
- `crystal spec spec/embedding_accumulate_precision_spec.cr` *(pending: CUDA not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68779a03be748331bc6ed22940551327