### PR TITLE
Add GPU SwiGLU backward kernel

### DIFF
--- a/src/shainet/cuda_stub.cr
+++ b/src/shainet/cuda_stub.cr
@@ -585,6 +585,10 @@ module SHAInet
       raise "CUDA kernels not available"
     end
 
+    def swiglu_backward(*args)
+      raise "CUDA kernels not available"
+    end
+
     def softmax_backward(*args)
       raise "CUDA kernels not available"
     end


### PR DESCRIPTION
## Summary
- add CUDA kernel for SwiGLU derivative
- expose `CUDA.swiglu_backward`
- hook PositionWiseFF backward to use the new kernel and drop CPU sync fallback

## Testing
- `crystal spec spec/swiglu_positionwise_ff_spec.cr --order random`
- `crystal spec spec/positionwise_ff_cuda_parity_spec.cr --order random`

------
https://chatgpt.com/codex/tasks/task_e_6877acd12c108331b10d44af81cc37b2