### PR TITLE
Add precision parameter to AttentionMask

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ net.train(
   log_each: 1000)
 ```
 
+### Streaming Data / GPU
+
+When streaming batches directly on the GPU (`gpu_batches: true`), any
+attention mask must be created with the same precision as the network.
+Use `AttentionMask.causal(seq_len, precision: net.precision)` (or
+`causal_cuda` on GPU) to avoid mismatched precisions.
+
 ### Learning Rate Scheduling
 
 Control the learning rate using warmup and decay:

--- a/examples/babylm_transformer.cr
+++ b/examples/babylm_transformer.cr
@@ -118,9 +118,9 @@ net.transformer_layers.first.positional_encoding = pos_enc
 
 # Causal mask so each position only attends to previous ones
 mask = if SHAInet::CUDA.fully_available?
-         SHAInet::GPUMemory.to_gpu(SHAInet::AttentionMask.causal(seq_len))
+         SHAInet::AttentionMask.causal_cuda(seq_len, precision: net.precision)
        else
-         SHAInet::AttentionMask.causal(seq_len)
+         SHAInet::AttentionMask.causal(seq_len, precision: net.precision)
        end
 net.transformer_layers.each { |l| l.mask = mask }
 

--- a/src/shainet/transformer/attention_mask.cr
+++ b/src/shainet/transformer/attention_mask.cr
@@ -3,8 +3,9 @@ module SHAInet
     NEG_INF = -1e9_f32
 
     # Returns a causal attention mask (lower triangular with 0 and -1e9 above diag)
-    def self.causal(size : Int32) : SimpleMatrix
-      mask = SimpleMatrix.new(size, size, 0.0)
+    # The mask matrix is allocated using the provided +precision+.
+    def self.causal(size : Int32, precision : Precision = Precision::Fp32) : SimpleMatrix
+      mask = SimpleMatrix.new(size, size, 0.0, precision)
       size.times do |i|
         ((i + 1)...size).each do |j|
           mask[i, j] = NEG_INF
@@ -14,9 +15,9 @@ module SHAInet
     end
 
     # Same as `causal` but returned as a CudaMatrix on supported systems
-    def self.causal_cuda(size : Int32) : CudaMatrix
+    def self.causal_cuda(size : Int32, precision : Precision = Precision::Fp32) : CudaMatrix
       raise "CUDA not available" unless CUDA.fully_available?
-      GPUMemory.to_gpu(causal(size)).as(CudaMatrix)
+      GPUMemory.to_gpu(causal(size, precision)).as(CudaMatrix)
     end
   end
 end


### PR DESCRIPTION
## Summary
- support configurable precision for AttentionMask.causal and causal_cuda
- use net.precision when building the causal mask in `babylm_transformer.cr`
- document precision requirement for GPU streaming in README

## Testing
- `crystal spec --order=random` *(fails: SHAInet::Autograd::Tensor matches numerical gradient, GELU activation matches numerical derivative, and cross entropy specs)*

------
https://chatgpt.com/codex/tasks/task_e_6878b92103c08331acc705bce772e15c